### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supported versions: GAFE01_00: Rev 0 (USA)
 
 ### MSYS2 Packages
 
-Open **MSYS2 MINGW32/64** from your Start menu and install:
+Open **MSYS2 MINGW32** from your Start menu and install:
 
 ```bash
 pacman -S mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-SDL2 git
@@ -29,7 +29,7 @@ pacman -S mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-SDL2 git
    cd ac-decomp
    ```
 
-2. Build (from **MSYS2 MINGW32/64** shell):
+2. Build (from **MSYS2 MINGW32** shell):
    ```bash
    ./build_pc.sh
    ```


### PR DESCRIPTION
1. Added git requirement to the pacman installation. MSYS2 doesn't come with git by default
2. Correct git clone command to actually clone into ac-decomp folder. Otherwise it will clone into "ACGC-PC-Port" by default.