### PR TITLE
Switch to Ninja build system and avoid Msys2 bash

### DIFF
--- a/build_pc.bat
+++ b/build_pc.bat
@@ -1,0 +1,27 @@
+@echo off
+if "%1"=="" (
+    set BUILD_NAME=pc/build32
+) else (
+    set BUILD_NAME=%1
+)
+
+if "%2"=="" (
+    set MINGW32=C:/msys64/mingw32
+) else (
+    set MINGW32=%2
+)
+
+set PATH=%MINGW32%/bin;%PATH%
+set SCRIPT_DIR=%~dp0
+set BUILD_DIR=%SCRIPT_DIR%%BUILD_NAME%
+
+echo "MINGW32 path: %MINGW32%"
+echo "BUILD_DIR: %BUILD_DIR%"
+
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+cd "%BUILD_DIR%"
+
+if not exist "Makefile" echo "=== Configuring CMake ===" && cmake %SCRIPT_DIR%/pc -G Ninja -DMINGW32=%MINGW32% -DCMAKE_TOOLCHAIN_FILE="%SCRIPT_DIR%/pc/cmake/Toolchain-ninja.cmake"
+
+echo "=== Building PC port ==="
+ninja

--- a/pc/cmake/Toolchain-ninja.cmake
+++ b/pc/cmake/Toolchain-ninja.cmake
@@ -1,0 +1,25 @@
+# CMake toolchain file for MinGW i686 (32-bit) cross-compilation from Linux
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR i686)
+
+if(NOT DEFINED MINGW32)
+    set(MINGW32 C:/msys64/mingw32)
+endif()
+
+# Compilers
+set(CMAKE_C_COMPILER   ${MINGW32}/bin/i686-w64-mingw32-gcc.exe)
+set(CMAKE_CXX_COMPILER ${MINGW32}/bin/i686-w64-mingw32-g++.exe)
+set(CMAKE_RC_COMPILER  ${MINGW32}/bin/windres.exe)
+
+# Linker / binutils
+set(CMAKE_LINKER       ${MINGW32}/i686-w64-mingw32/bin/ld.exe)
+set(CMAKE_AR           ${MINGW32}/i686-w64-mingw32/bin/ar.exe)
+set(CMAKE_RANLIB       ${MINGW32}/i686-w64-mingw32/bin/ranlib.exe)
+set(CMAKE_STRIP        ${MINGW32}/i686-w64-mingw32/bin/strip.exe)
+
+# Sysroot / search paths
+set(CMAKE_FIND_ROOT_PATH ${MINGW32})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)  # don't look here for tools
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)   # only look here for libs
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)   # only look here for headers
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)   # only look here for packages


### PR DESCRIPTION
While Msys2 is still being used i only set the path variable to include the path in the .bat file
This avoids having to load the mingw32 bash as the installer doesn't always create an accessible Shortcut in the Start menu.
This way you can just run it from cmd or by double-clicking `build_pc.bat`.

Besides this, switching to ninja also offers a hugee performance boost not only for a full (re)build but also if no source files change, with mingw32-make it would take 5-6 seconds to detect that nothing changed (running the Debugger in my IDE triggers the build tool).
With ninja a full rebuild feels 2-3x faster and if no source files changed it's near instant.

Are there any good reasons the project went away from ninja in the decomp and switched to mingw32-make?

The build_pc.bat file allows for 2 **optional** arguments to override the default build output path and msys2 mingw32 path
e.g. `build_pc.bat pc/custom_build C:/custom/path/to/msys64/mingw32`
this will also be passed to the toolchain file

Default values are BUILD_NAME=pc/build32 and MINGW32=C:/msys64/mingw32

Since ninja ships with msys2's mingw32 it should work out of the box too