### PR TITLE
Fix clear color logic when TARGET_PC or BUGFIXES is defined

### DIFF
--- a/src/game/m_rcp.c
+++ b/src/game/m_rcp.c
@@ -376,6 +376,36 @@ extern Gfx* two_tex_scroll_dolphin(GRAPH* graph, int tile1, int x1, int y1, int 
     return dl;
 }
 
+// @BUG - we don't need to clear the screen by drawing a full screen quad with the clear color,
+// as JW_setClearColor handles that for us.
+#if defined(BUGFIXES) || defined(TARGET_PC)
+extern void DisplayList_initialize(GRAPH* graph, u8 clear_r, u8 clear_g, u8 clear_b, GAME* game) {
+    OPEN_DISP(graph);
+
+    gSPDisplayList(NOW_POLY_OPA_DISP++, RSP_RDP_clear_data);
+    gSPDisplayList(NOW_POLY_XLU_DISP++, RSP_RDP_clear_data);
+    gSPDisplayList(NOW_OVERLAY_DISP++, RSP_RDP_clear_data);
+    gSPDisplayList(NOW_FONT_DISP++, RSP_RDP_clear_data);
+    gSPDisplayList(NOW_BG_OPA_DISP++, RSP_RDP_clear_data);
+    gSPDisplayList(NOW_BG_XLU_DISP++, z_gsCPModeSet_Data[2]);
+    gSPDisplayList(NOW_SHADOW_DISP++, z_gsCPModeSet_Data[2]);
+    gSPDisplayList(NOW_LIGHT_DISP++, z_gsCPModeSet_Data[2]);
+
+    gDPSetScissor(NOW_POLY_OPA_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+    gDPSetScissor(NOW_POLY_XLU_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+    gDPSetScissor(NOW_OVERLAY_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+    gDPSetScissor(NOW_FONT_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+    gDPSetScissor(NOW_SHADOW_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+    gDPSetScissor(NOW_LIGHT_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+    gDPSetScissor(NOW_BG_OPA_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+    gDPSetScissor(NOW_BG_XLU_DISP++, G_SC_NON_INTERLACE, 0, 0, 640, 480);
+
+    CLOSE_DISP(graph);
+
+    JW_setClearColor(clear_r, clear_g, clear_b);
+    mFont_Main_start(graph);
+}
+#else
 extern void DisplayList_initialize(GRAPH* graph, u8 clear_r, u8 clear_g, u8 clear_b, GAME* game) {
     OPEN_DISP(graph);
 
@@ -410,6 +440,7 @@ extern void DisplayList_initialize(GRAPH* graph, u8 clear_r, u8 clear_g, u8 clea
 
     mFont_Main_start(graph);
 }
+#endif
 
 extern void fade_rgba8888_draw(Gfx** gfxp, u32 alpha) {
     static Gfx fade_gfx[6] = {


### PR DESCRIPTION
On N64 the programmer is responsible for clearing the screen. This was generally done by drawing a fullscreen quad with the desired clear color as the first draw step.

On the GameCube this is handled through GX, and during the porting process the devs correctly utilized JW_setClearColor. However, they forgot to remove the N64 color clearing logic. That causes a one-frame flicker whenever the clear color changes, which is resolved by this PR.

The other required changes seem to already be in place.