### PR TITLE
Mouse support

### DIFF
--- a/include/m_design_ovl.h
+++ b/include/m_design_ovl.h
@@ -96,6 +96,16 @@ struct design_ovl_s {
     u8 _6DA;
     u8 _6DB;
     u8 _6DC;
+#ifdef MOUSE_INPUT
+    int mouse_active;
+    int centered_x;
+    int centered_y;
+    int mouse_tool_active;
+    int mouse_tool_x;
+    int mouse_tool_y;
+    int prev_cursor_x;
+    int prev_cursor_y;
+#endif
 };
 
 extern void mDE_maskcat_init(MaskCat_c* mask_cat);

--- a/include/m_hand_ovl.h
+++ b/include/m_hand_ovl.h
@@ -56,6 +56,7 @@ typedef struct hand_info_s {
     u8 catch_pg;
     s16 haniwa_item_cond;
     u32 haniwa_item_price;
+    f32 visual_pos[2]; // Visual position (so mouse follows smoothly)
 } mHD_hand_info_c;
 
 /* sizeof(struct hand_ovl_s) == 0x378 */

--- a/include/m_tag_ovl.h
+++ b/include/m_tag_ovl.h
@@ -289,6 +289,16 @@ struct tag_ovl_s {
     /* 0x376 */ u16 _02;
     /* 0x378 */ mTG_cporiginal_mark_entry_c original_entries[mTG_ORG_TYPE_NUM];
     /* 0x390 */ mTG_mark_original_c original_mark;
+#ifdef MOUSE_INPUT
+    /* 0x??? */ u8 mouse_active;
+    /* 0x??? */ s32 mouse_x;
+    /* 0x??? */ s32 mouse_y;
+    /* 0x??? */ int hovered_table;
+    /* 0x??? */ int hovered_idx;
+    /* 0x??? */ int hovered_col;
+    /* 0x??? */ int hovered_row;
+    /* 0x??? */ int hovered_option;
+#endif
 };
 
 extern int mTG_mark_main(Submenu*, mSM_MenuInfo_c*, int, int*);

--- a/pc/CMakeLists.txt
+++ b/pc/CMakeLists.txt
@@ -40,6 +40,7 @@ add_compile_definitions(
     _LANGUAGE_C    # Required for N64 GBI/ultratypes headers
     PC_ENHANCEMENTS   # Optional visual improvements (MSAA, etc). Remove to get pure PC port.
     KEYBOARD_TYPING   # Physical keyboard typing in text editor. Remove for platforms without keyboards.
+    MOUSE_INPUT       # Mouse input for menu and misc interfaces. Remove for platforms without mouse.
 )
 
 # Common compiler flags (applied to all sources)
@@ -275,6 +276,7 @@ set(PC_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_dvd.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_pad.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_typing.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_mouse.c
     ${DECOMP_ROOT}/src/static/dolphin/pad/Padclamp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_card.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_vi.c

--- a/pc/include/pc_mouse.h
+++ b/pc/include/pc_mouse.h
@@ -1,0 +1,59 @@
+#ifndef PC_MOUSE_H
+#define PC_MOUSE_H
+
+#include "pc_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef MOUSE_INPUT
+
+/* mouse constants */
+#define PC_MOUSE_BUTTON_LEFT    (1 << 0)
+#define PC_MOUSE_BUTTON_MIDDLE  (1 << 1)
+#define PC_MOUSE_BUTTON_RIGHT   (1 << 2)
+#define PC_MOUSE_BUTTON_X1      (1 << 3)
+#define PC_MOUSE_BUTTON_X2      (1 << 4)
+#define PC_MOUSE_WHEEL_UP       (1 << 5)
+#define PC_MOUSE_WHEEL_DOWN     (1 << 6)
+
+extern s32 g_mouse_wheel_delta;
+
+u32 pc_mouse_button_held(void);
+u32 pc_mouse_button_pressed(void);
+u32 pc_mouse_button_released(void);
+void pc_mouse_lock(s32 lock);
+int pc_mouse_is_locked(void);
+s32 pc_mouse_scroll_wheel(void);
+void pc_mouse_get_position(s32 *x, s32 *y);
+void pc_mouse_get_delta(s32 *dx, s32 *dy);
+int pc_mouse_moved(void);
+int pc_mouse_active(void);
+void pc_mouse_get_native_position(s32 *x, s32 *y);
+void pc_mouse_update(void);
+
+#else
+
+#define g_mouse_wheel_delta   0
+
+u32 pc_mouse_button_held(void) { return 0; }
+u32 pc_mouse_button_pressed(void) { (return 0; }
+u32 pc_mouse_button_released(void) { return 0; }
+void pc_mouse_lock(s32 lock) { (void)lock; }
+int pc_mouse_is_locked(void) { return 0; }
+s32 pc_mouse_scroll_wheel(void) { return 0; }
+void pc_mouse_get_position(s32 *x, s32 *y) { (void)x; (void)y; }
+void pc_mouse_get_delta(s32 *dx, s32 *dy)  { (void)dx; (void)dy; }
+int pc_mouse_moved(void) { return 0; }
+int pc_mouse_active(void) { return 0; }
+void pc_mouse_get_native_position(s32 *x, s32 *y)  { (void)x; (void)y; }
+void pc_mouse_update(void) {}
+
+#endif /* MOUSE_INPUT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PC_MOUSE_H */

--- a/pc/src/pc_gx.c
+++ b/pc/src/pc_gx.c
@@ -18,9 +18,9 @@ PCGXState g_gx;
 
 #ifdef PC_ENHANCEMENTS
 /* Aspect correction: factor = gc_aspect/actual_aspect, offset = content left edge in GC coords */
-static float g_aspect_factor = 1.0f;
-static float g_aspect_offset = 0.0f;
-static int   g_aspect_active = 0;
+float g_aspect_factor = 1.0f;
+float g_aspect_offset = 0.0f;
+int   g_aspect_active = 0;
 
 static void pc_gx_update_aspect(void) {
     float gc_aspect = (float)PC_GC_WIDTH / (float)PC_GC_HEIGHT;

--- a/pc/src/pc_main.c
+++ b/pc/src/pc_main.c
@@ -7,6 +7,7 @@
 #include "pc_assets.h"
 #include "pc_disc.h"
 #include "pc_typing.h"
+#include "pc_mouse.h"
 
 /* prefer discrete GPU on laptops */
 #ifdef _WIN32
@@ -245,6 +246,11 @@ int pc_platform_poll_events(void) {
                     pc_platform_update_window_size();
                 }
                 break;
+#ifdef MOUSE_INPUT
+            case SDL_MOUSEWHEEL:
+                g_mouse_wheel_delta += event.wheel.y;
+                break;
+#endif
             case SDL_KEYDOWN:
                 if (event.key.keysym.sym == SDLK_ESCAPE) {
                     if (pc_confirm_quit()) {
@@ -263,6 +269,9 @@ int pc_platform_poll_events(void) {
                 break;
         }
     }
+
+    pc_mouse_update();
+
     return 1;
 }
 

--- a/pc/src/pc_mouse.c
+++ b/pc/src/pc_mouse.c
@@ -1,0 +1,146 @@
+/* pc_mouse.c - Mouse input mode for menus and misc interfaces.
+ * When an interface is active, mouse can be used to interact with it.
+ * There's helpers to see when a mouse is moved, wheel movement and clicks. */
+
+#include "pc_mouse.h"
+
+#ifdef MOUSE_INPUT
+static s32 g_mouse_x = 0, g_mouse_y = 0;
+static s32 g_mouse_dx = 0, g_mouse_dy = 0;
+static s32 g_mouse_locked = 0;
+static s32 g_prev_mouse_x = 0, g_prev_mouse_y = 0;
+static s32 g_mouse_moved = 0;
+static u32 g_mouse_buttons_current = 0;
+static u32 g_mouse_buttons_previous = 0;
+static int g_mouse_active_this_frame = 0;
+
+s32 g_mouse_wheel_delta = 0;
+
+u32 pc_mouse_button_held(void) {
+    return g_mouse_buttons_current;
+}
+
+u32 pc_mouse_button_pressed(void) {
+    return (g_mouse_buttons_current & ~g_mouse_buttons_previous);
+}
+
+u32 pc_mouse_button_released(void) {
+    return (~g_mouse_buttons_current & g_mouse_buttons_previous);
+}
+
+void pc_mouse_lock(s32 lock) {
+    g_mouse_locked = !!lock;
+    SDL_SetRelativeMouseMode(g_mouse_locked);
+}
+
+int pc_mouse_is_locked(void) {
+    return g_mouse_locked;
+}
+
+s32 pc_mouse_scroll_wheel(void) {
+    s32 wheel = g_mouse_wheel_delta;
+    if (g_mouse_wheel_delta) g_mouse_wheel_delta = 0;
+    return wheel;
+}
+
+void pc_mouse_get_position(s32 *x, s32 *y) {
+    if (x) *x = g_mouse_x;
+    if (y) *y = g_mouse_y;
+}
+
+void pc_mouse_get_delta(s32 *dx, s32 *dy) {
+    if (dx) *dx = g_mouse_dx;
+    if (dy) *dy = g_mouse_dy;
+}
+
+int pc_mouse_moved(void) {
+    return g_mouse_moved;
+}
+
+int pc_mouse_active(void) {
+    return g_mouse_active_this_frame;
+}
+
+#ifdef PC_ENHANCEMENTS
+extern float g_aspect_factor;
+extern float g_aspect_offset;
+extern int   g_aspect_active;
+#endif
+
+/* Scale mouse position to the native's game window.
+ * Makes it easier to interact with menus. */
+void pc_mouse_get_native_position(s32 *x, s32 *y) {
+    s32 mouse_x, mouse_y;
+    f32 scaled_x, scaled_y;
+    
+    pc_mouse_get_position(&mouse_x, &mouse_y);
+    
+    if (g_pc_window_w > 0 && g_pc_window_h > 0) {
+#ifdef PC_ENHANCEMENTS
+        if (g_aspect_active) {
+            scaled_x = ((f32)mouse_x * PC_GC_WIDTH) / g_pc_window_w;
+            scaled_x = (scaled_x - g_aspect_offset) / g_aspect_factor;
+
+            scaled_y = ((f32)mouse_y * PC_GC_HEIGHT) / g_pc_window_h;
+        } else
+#endif
+        {
+            scaled_x = ((f32)mouse_x * PC_GC_WIDTH) / g_pc_window_w;
+            scaled_y = ((f32)mouse_y * PC_GC_HEIGHT) / g_pc_window_h;
+        }
+    } else {
+        scaled_x = (f32)mouse_x;
+        scaled_y = (f32)mouse_y;
+    }
+    
+    if (x) *x = (s32)scaled_x;
+    if (y) *y = (s32)scaled_y;
+}
+
+void pc_mouse_update(void) {
+    g_mouse_buttons_previous = g_mouse_buttons_current;
+
+    s32 mx, my;
+    u32 sdl_buttons = SDL_GetMouseState((int*)&mx, (int*)&my);
+    g_mouse_buttons_current = 0;
+
+    /* Convert each SDL button to our bitflag system */
+    if (sdl_buttons & SDL_BUTTON(SDL_BUTTON_LEFT))   g_mouse_buttons_current |= PC_MOUSE_BUTTON_LEFT;
+    if (sdl_buttons & SDL_BUTTON(SDL_BUTTON_MIDDLE)) g_mouse_buttons_current |= PC_MOUSE_BUTTON_MIDDLE;
+    if (sdl_buttons & SDL_BUTTON(SDL_BUTTON_RIGHT))  g_mouse_buttons_current |= PC_MOUSE_BUTTON_RIGHT;
+    if (sdl_buttons & SDL_BUTTON(SDL_BUTTON_X1))     g_mouse_buttons_current |= PC_MOUSE_BUTTON_X1;
+    if (sdl_buttons & SDL_BUTTON(SDL_BUTTON_X2))     g_mouse_buttons_current |= PC_MOUSE_BUTTON_X2;
+
+    int wheel_active = 0;
+    if (g_mouse_wheel_delta > 0) {
+        g_mouse_buttons_current |= PC_MOUSE_WHEEL_UP;
+        wheel_active = 1;
+    } else if (g_mouse_wheel_delta < 0) {
+        g_mouse_buttons_current |= PC_MOUSE_WHEEL_DOWN;
+        wheel_active = 1;
+    }
+
+    g_mouse_moved = (mx != g_prev_mouse_x || my != g_prev_mouse_y);
+
+    g_mouse_active_this_frame = (g_mouse_moved || 
+                                 (g_mouse_buttons_current & ~(PC_MOUSE_WHEEL_UP | PC_MOUSE_WHEEL_DOWN)) ||
+                                 wheel_active);
+    
+    s32 mdx = 0, mdy = 0;
+    SDL_GetRelativeMouseState((int*)&mdx, (int*)&mdy);
+    
+    if (g_mouse_locked) {
+        g_mouse_dx = mdx;
+        g_mouse_dy = mdy;
+    } else {
+        g_mouse_dx = mx - g_mouse_x;
+        g_mouse_dy = my - g_mouse_y;
+    }
+
+    g_prev_mouse_x = g_mouse_x;
+    g_prev_mouse_y = g_mouse_y;
+    g_mouse_x = mx;
+    g_mouse_y = my;
+}
+
+#endif /* MOUSE_INPUT */

--- a/src/game/m_choice_main_normal.c_inc
+++ b/src/game/m_choice_main_normal.c_inc
@@ -7,13 +7,73 @@ static void mChoice_determimation_set(mChoice_c* choice) {
     choice_data->selected_choice_idx = idx;
 }
 
+#ifdef MOUSE_INPUT
+    #define GET_BUTTON_PRESSED(b, m) chkTrigger(b) || ((pc_mouse_button_pressed() & m) && hover_idx != -1)
+#else
+    #define GET_BUTTON_PRESSED(b, m) chkTrigger(b)
+#endif
+
+#ifdef MOUSE_INPUT
+static int mChoice_GetMouseHoverIdx(mChoice_c* choice, f32 mx, f32 my) {
+    // Calculate the offset applied by mChoice_SetMatrix
+    f32 offset_x = (choice->center_x - 160.0f);
+    f32 offset_y = (-choice->center_y + 120.0f);
+    f32 scale = choice->scale;
+
+    // Adjust mouse position based on the menu's translation
+    f32 local_mx = (mx - offset_x);
+    f32 local_my = (my + offset_y);
+
+    if (scale > 0.0f && scale != 1.0f) {
+        local_mx /= scale;
+        local_my /= scale;
+    }
+
+    // Now do hitbox check
+    f32 tx = choice->text_x;
+    f32 ty = choice->text_y;
+    
+    for (int i = 0; i < choice->data.choice_num; i++) {
+        f32 line_top = ty + (i * 16.0f);
+        f32 line_bottom = line_top + 16.0f;
+        
+        if (local_my >= line_top && local_my < line_bottom) {
+            // Horizontal check (Assuming ~8 units per character)
+            f32 text_w = (f32)choice->data.string_lens[i] * 8.0f;
+            if (local_mx >= tx && local_mx < (tx + text_w)) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+#endif
+
 static int mChoice_Main_Normal_SetChoice(mChoice_c* choice, GAME* game) {
     int res = FALSE;
 
-    if (chkTrigger(BUTTON_A)) {
+#ifdef MOUSE_INPUT
+    // Mouse movement
+    int nmx, nmy;
+    pc_mouse_get_native_position(&nmx, &nmy);
+    f32 mx = (f32)nmx * 0.5f;
+    f32 my = (f32)nmy * 0.5f;
+
+    // Update selection via hover
+    int hover_idx = mChoice_GetMouseHoverIdx(choice, mx, my);
+    if (pc_mouse_active() && hover_idx != -1 && hover_idx != choice->selected_choice_idx) {
+        choice->selected_choice_idx = hover_idx;
+        mChoice_sound_CURSOL(); 
+        
+        choice->choice_automove_type = mChoice_AUTOMOVE_STOPPED;
+        choice->choice_automove_timer = 0.0f;
+    }
+#endif
+
+    if (GET_BUTTON_PRESSED(BUTTON_A, 1 << 0)) {
         mChoice_determimation_set(choice);
         res = TRUE;
-    } else if (choice->no_b_flag && chkTrigger(BUTTON_B)) {
+    } else if (choice->no_b_flag && GET_BUTTON_PRESSED(BUTTON_B, 1 << 2)) {
         choice->selected_choice_idx = choice->data.choice_num - 1;
         mChoice_determimation_set(choice);
         res = TRUE;

--- a/src/game/m_design_ovl.c
+++ b/src/game/m_design_ovl.c
@@ -1010,12 +1010,29 @@ void mDE_undo(mDE_Ovl_c* design_ovl) {
     bcopy(&design_ovl->texture, &design_ovl->undo_texture, sizeof(design_ovl->texture));
 }
 
+#ifdef MOUSE_INPUT
+    #define GET_BUTTON_PRESSED(b, m) chkTrigger(b) || (pc_mouse_button_pressed() & m)
+    #define GET_BUTTON_HELD(b, m) chkButton(b) || (pc_mouse_button_held() & m)
+#else
+    #define GET_BUTTON_PRESSED(b, m) chkTrigger(b)
+    #define GET_BUTTON_HELD(b, m) chkButton(b)
+#endif
+
 void mDE_main_pen_move(mDE_Ovl_c* design_ovl) {
     design_ovl->_699 = 0;
     design_ovl->_698 = 1;
-    if (chkTrigger(BUTTON_A)) {
+#ifdef MOUSE_INPUT
+    int current_x = design_ovl->cursor_x;
+    int current_y = design_ovl->cursor_y;
+#endif
+
+    if (GET_BUTTON_PRESSED(BUTTON_A, 1 << 0)) {
         design_ovl->_6CC = 1;
         mDE_set_undo_texture(design_ovl);
+#ifdef MOUSE_INPUT
+        design_ovl->prev_cursor_x = current_x;
+        design_ovl->prev_cursor_y = current_y;
+#endif
         switch (design_ovl->_6A0) {
             case 1: {
                 sAdo_SysTrgStart(0x451);
@@ -1027,8 +1044,9 @@ void mDE_main_pen_move(mDE_Ovl_c* design_ovl) {
                 sAdo_SysTrgStart(0x450);
             } break;
         }
-    } else if (chkButton(BUTTON_A) && design_ovl->_6CC) {
+    } else if (GET_BUTTON_HELD(BUTTON_A, 1 << 0) && design_ovl->_6CC) {
         mDE_get_pal_on_cursor(design_ovl, design_ovl->cursor_x, design_ovl->cursor_y);
+#ifndef MOUSE_INPUT
         switch (design_ovl->_6A0) {
             case 1: {
                 mDE_set_texture_template(design_ovl, mDE_pen_2, design_ovl->cursor_x, design_ovl->cursor_y, 2, 2, 0, 1);
@@ -1040,7 +1058,66 @@ void mDE_main_pen_move(mDE_Ovl_c* design_ovl) {
                 mDE_set_pal_on_cursor(design_ovl, design_ovl->cursor_x, design_ovl->cursor_y, design_ovl->_6A4);
             } break;
         }
+#else
+        int prev_x = design_ovl->prev_cursor_x;
+        int prev_y = design_ovl->prev_cursor_y;
+        
+        if (prev_x == -1 || prev_y == -1) {
+            prev_x = current_x;
+            prev_y = current_y;
+        }
+        
+        // Calculate steps for interpolation (Manhattan)
+        int dx = current_x - prev_x;
+        int dy = current_y - prev_y;
+        int steps = ABS(dx) + ABS(dy);
+
+        if (steps > 1 && pc_mouse_button_held() & (1 << 0)) {
+            // Interpolate between previous and current positions then draw
+            for (int step = 1; step <= steps; step++) {
+                int interp_x = prev_x + (dx * step) / steps;
+                int interp_y = prev_y + (dy * step) / steps;
+
+                switch (design_ovl->_6A0) {
+                    case 1: {
+                        mDE_set_texture_template(design_ovl, mDE_pen_2, interp_x, interp_y, 2, 2, 0, 1);
+                    } break;
+                    case 2: {
+                        mDE_set_texture_template(design_ovl, mDE_pen_3, interp_x, interp_y, 3, 3, 0, 2);
+                    } break;
+                    default: {
+                        mDE_set_pal_on_cursor(design_ovl, interp_x, interp_y, design_ovl->_6A4);
+                    } break;
+                }
+            }
+        } else {
+            switch (design_ovl->_6A0) {
+                case 1: {
+                    mDE_set_texture_template(design_ovl, mDE_pen_2, current_x, current_y, 2, 2, 0, 1);
+                } break;
+                case 2: {
+                    mDE_set_texture_template(design_ovl, mDE_pen_3, current_x, current_y, 3, 3, 0, 2);
+                } break;
+                default: {
+                    mDE_set_pal_on_cursor(design_ovl, current_x, current_y, design_ovl->_6A4);
+                } break;
+            }
+        }
+
+        design_ovl->prev_cursor_x = current_x;
+        design_ovl->prev_cursor_y = current_y;
+#endif
     }
+#ifdef MOUSE_INPUT
+    else {
+        if (design_ovl->_6CC) {
+            design_ovl->_6CC = 0;
+            design_ovl->prev_cursor_x = -1;
+            design_ovl->prev_cursor_y = -1;
+        }
+    }
+#endif
+
     switch (design_ovl->_6A0) {
         case 1: {
             if (design_ovl->cursor_y == mDE_POS_MIN) {
@@ -1120,7 +1197,7 @@ void mDE_main_pen_move(mDE_Ovl_c* design_ovl) {
 
 void mDE_main_nuri_move(mDE_Ovl_c* design_ovl) {
     design_ovl->_699 = 1;
-    if (chkTrigger(BUTTON_A)) {
+    if (GET_BUTTON_PRESSED(BUTTON_A, 1 << 0)) {
         sAdo_SysTrgStart(0x455);
         mDE_set_undo_texture(design_ovl);
         mDE_paint(design_ovl, design_ovl->_6A4);
@@ -1307,7 +1384,7 @@ void mDE_main_waku_move(mDE_Ovl_c* design_ovl) {
         design_ovl->_688 = ABS(design_ovl->_678 - design_ovl->cursor_x) + 1;
         design_ovl->_68C = ABS(design_ovl->_67C - design_ovl->cursor_y) + 1;
     }
-    if (chkTrigger(BUTTON_A)) {
+    if (GET_BUTTON_PRESSED(BUTTON_A, 1 << 0)) {
         if (design_ovl->_69A == 0) {
             design_ovl->_658 = design_ovl->_650;
             design_ovl->_65C = design_ovl->_654;
@@ -1355,7 +1432,7 @@ void mDE_main_waku_move(mDE_Ovl_c* design_ovl) {
         design_ovl->_69A = !design_ovl->_69A;
     }
 
-    if (chkTrigger(BUTTON_B) && design_ovl->_69A == TRUE) {
+    if (GET_BUTTON_PRESSED(BUTTON_B, 1 << 2) && design_ovl->_69A == TRUE) {
         design_ovl->_69A = 0;
         design_ovl->_698 = 0;
         design_ovl->_680 = 0;
@@ -1401,7 +1478,7 @@ void mDE_main_mark_move(mDE_Ovl_c* design_ovl) {
             } break;
         }
     }
-    if (chkTrigger(BUTTON_A)) {
+    if (GET_BUTTON_PRESSED(BUTTON_A, 1 << 0)) {
         mDE_set_undo_texture(design_ovl);
         sAdo_SysTrgStart(0x455);
         if (Save_Get(scene_no) == SCENE_START_DEMO3 || GETREG(NMREG, 0x5f)) {
@@ -1452,7 +1529,7 @@ void mDE_main_mark_move(mDE_Ovl_c* design_ovl) {
 
 void mDE_main_undo_move(mDE_Ovl_c* design_ovl) {
     design_ovl->_699 = 7;
-    if (chkTrigger(BUTTON_A)) {
+    if (GET_BUTTON_PRESSED(BUTTON_A, 1 << 0)) {
         mDE_undo(design_ovl);
     }
 }
@@ -1709,9 +1786,102 @@ void mDE_mode_stick_control_analog(mDE_Ovl_c* design_ovl) {
     mDE_cursor_analog_move(design_ovl);
 }
 
+#ifdef MOUSE_INPUT
+// Checks if a point (px, py) is inside a rectangle defined in these coordinates.
+// min_x = left edge - min_y = bottom edge - max_x = right edge - max_y = top edge
+static int mDE_point_in_rect(f32 px, f32 py, f32 min_x, f32 min_y, f32 max_x, f32 max_y) {
+    return (px >= min_x && px <= max_x && py >= min_y && py <= max_y);
+}
+
+void mDE_mode_main_mouse_move(mDE_Ovl_c* design_ovl) {
+    // Mouse center position to grid area
+    const f32 design_area = 77.5f; // 75 + 2.5
+    int new_cursor_x = (int)((design_ovl->centered_x + design_area) / 5.0f);
+    int new_cursor_y = (int)(-(design_ovl->centered_y - design_area) / 5.0f);
+
+    // Pen grid max bounds check
+    int min = 0;
+    if (design_ovl->main_mode_act == mDE_MAIN_MODE_PEN) {
+        switch (design_ovl->_6A0) {
+            case 1:
+                min = 1;
+                break;
+            case 2:
+                min = 2;
+                break;
+        }
+    }
+
+    // Clamp to valid grid range
+    if (new_cursor_x < mDE_POS_MIN) new_cursor_x = mDE_POS_MIN;
+    if (new_cursor_x > mDE_POS_MAX - min) new_cursor_x = mDE_POS_MAX - min;
+    if (new_cursor_y < mDE_POS_MIN) new_cursor_y = mDE_POS_MIN;
+    if (new_cursor_y > mDE_POS_MAX - min) new_cursor_y = mDE_POS_MAX - min;
+    
+    // Update cursor position
+    if (new_cursor_x != design_ovl->cursor_x || new_cursor_y != design_ovl->cursor_y) {
+        design_ovl->cursor_x = new_cursor_x;
+        design_ovl->cursor_y = new_cursor_y;
+        design_ovl->_650 = design_ovl->cursor_x * 5;
+        design_ovl->_654 = -design_ovl->cursor_y * 5;
+        design_ovl->_660 = design_ovl->_650 + 2.5f;
+        design_ovl->_664 = design_ovl->_654 - 2.5f;
+        
+        sAdo_SysTrgStart(0x453);
+    }
+
+    // Waku cursor orientation check    
+    if (pc_mouse_moved() && design_ovl->main_mode_act == mDE_MAIN_MODE_WAKU) {
+        if (design_ovl->_69A && design_ovl->_699 != 9) {
+            // Calculate orientation based on cursor position relative to start point
+            if (design_ovl->cursor_x >= design_ovl->_678 && design_ovl->cursor_y <= design_ovl->_67C) {
+                design_ovl->_6D8 = 1; // right-top
+            } else if (design_ovl->cursor_x >= design_ovl->_678 && design_ovl->cursor_y >= design_ovl->_67C) {
+                design_ovl->_6D8 = 0; // right-bottom
+            } else if (design_ovl->cursor_x <= design_ovl->_678 && design_ovl->cursor_y <= design_ovl->_67C) {
+                design_ovl->_6D8 = 3; // left-top
+            } else if (design_ovl->cursor_x <= design_ovl->_678 && design_ovl->cursor_y >= design_ovl->_67C) {
+                design_ovl->_6D8 = 2; // left-bottom
+            }
+            design_ovl->_6D9 = design_ovl->_6D8;
+
+            // Update selection box dimensions for visual feedback
+            int x_start, y_start, x_end, y_end;
+            if (design_ovl->_678 > design_ovl->cursor_x) {
+                x_start = design_ovl->cursor_x;
+                x_end = design_ovl->_678;
+            } else {
+                x_start = design_ovl->_678;
+                x_end = design_ovl->cursor_x;
+            }
+            
+            if (design_ovl->_67C > design_ovl->cursor_y) {
+                y_start = design_ovl->cursor_y;
+                y_end = design_ovl->_67C;
+            } else {
+                y_start = design_ovl->_67C;
+                y_end = design_ovl->cursor_y;
+            }
+            
+            design_ovl->_680 = x_start * 5;
+            design_ovl->_684 = -y_start * 5;
+            design_ovl->_688 = (x_end - x_start) + 1;
+            design_ovl->_68C = (y_end - y_start) + 1;
+        }
+    }
+}
+#endif
+
 void mDE_mode_main_move(mDE_Ovl_c* design_ovl) {
     design_ovl->move_pR = gamePT->mcon.move_pR;
     design_ovl->_6C4 = 1;
+ 
+#ifdef MOUSE_INPUT
+    if (design_ovl->mouse_active) {
+        mDE_mode_main_mouse_move(design_ovl);
+    }
+#endif
+
     if (design_ovl->main_mode_act == mDE_MAIN_MODE_PEN && chkButton(BUTTON_A)) {
         design_ovl->_6C4 = 3;
         if (GETREG(NMREG, 0x13)) {
@@ -1763,10 +1933,10 @@ void mDE_mode_main_move(mDE_Ovl_c* design_ovl) {
         }
     }
 
-    if (chkTrigger(BUTTON_B) && design_ovl->_69A == 0) {
+    if (GET_BUTTON_PRESSED(BUTTON_B, 1 << 2) && design_ovl->_69A == 0) {
         design_ovl->_6CD = 1;
         design_ovl->_6A4 = mDE_get_pal_on_cursor(design_ovl, design_ovl->cursor_x, design_ovl->cursor_y);
-    } else if (chkButton(BUTTON_B) && design_ovl->_69A == 0 && design_ovl->_6CD) {
+    } else if (GET_BUTTON_HELD(BUTTON_B, 1 << 2) && design_ovl->_69A == 0 && design_ovl->_6CD) {
         design_ovl->_6DB = 1;
         design_ovl->_6A4 = mDE_get_pal_on_cursor(design_ovl, design_ovl->cursor_x, design_ovl->cursor_y);
     } else if (design_ovl->_6DB) {
@@ -1869,7 +2039,7 @@ void mDE_mode_main_move(mDE_Ovl_c* design_ovl) {
         }
         mDE_mode_main_shortcut_tool(design_ovl, 4);
     }
-    if (chkTrigger(BUTTON_X)) {
+    if (GET_BUTTON_PRESSED(BUTTON_X, 1 << 1)) {
         design_ovl->_69D = !design_ovl->_69D;
         if (design_ovl->_69D == FALSE) {
             sAdo_SysTrgStart(0x457);
@@ -1884,10 +2054,71 @@ void mDE_mode_main_move(mDE_Ovl_c* design_ovl) {
         mDE_print_texture(design_ovl);
     }
     design_ovl->main_mode_proc(design_ovl);
-    if (chkButton(BUTTON_B) && design_ovl->_69A == 0 && design_ovl->_6CD) {
+    if (GET_BUTTON_HELD(BUTTON_B, 1 << 2) && design_ovl->_69A == 0 && design_ovl->_6CD) {
         design_ovl->_699 = 8;
     }
 }
+
+#ifdef MOUSE_INPUT
+void mDE_mode_pallet_mouse_move(mDE_Ovl_c* design_ovl) {
+    int color_index = -1;
+
+    const f32 cx   = 110.0f;
+    const f32 step = 10.0f;
+
+    for (int i = 0; i < 16; i++) {
+        f32 cy = (i == 0) ? 63.0f : 63.0f - i * step;
+
+        f32 half_h = (i == 0) ? 12.0f : 5.0f;
+
+        if (mDE_point_in_rect(design_ovl->centered_x, design_ovl->centered_y,
+                              cx - 15.0f, cy - half_h,
+                              cx + 15.0f, cy + half_h)) {
+            color_index = i;
+            break;
+        }
+    }
+
+    if (color_index >= 0 && color_index <= 15) {
+        u32 mouse_pressed = pc_mouse_button_pressed();
+
+        if (design_ovl->_6A5 != color_index) {
+            design_ovl->_6A5 = color_index;
+            sAdo_SysTrgStart(0x459);
+        }
+
+        if (design_ovl->_6A5 == 0) {
+            if (mouse_pressed & (1 << 0)) {
+                // Left click cycles palette forwards
+                sAdo_SysTrgStart(0x458);
+                design_ovl->palette_no++;
+                if (design_ovl->palette_no >= 0x10) {
+                    design_ovl->palette_no = 0;
+                }
+                design_ovl->palette_p = mNW_PaletteIdx2Palette(design_ovl->palette_no);
+                mDE_pallet_RGB5A3_to_RGB24(design_ovl);
+            }
+            if (mouse_pressed & (1 << 2)) {
+                // Right click cycles palette backwards
+                sAdo_SysTrgStart(0x458);
+                if (design_ovl->palette_no == 0) {
+                    design_ovl->palette_no = 0xf;
+                } else {
+                    design_ovl->palette_no--;
+                }
+                design_ovl->palette_p = mNW_PaletteIdx2Palette(design_ovl->palette_no);
+                mDE_pallet_RGB5A3_to_RGB24(design_ovl);
+            }
+        } else {
+            if (mouse_pressed & (1 << 0)) {
+                // Click to select color
+                sAdo_SysTrgStart(0x45a);
+                design_ovl->_6A4 = design_ovl->_6A5;
+            }
+        }
+    }
+}
+#endif
 
 void mDE_mode_pallet_move(mDE_Ovl_c* design_ovl) {
     int old6A5 = design_ovl->_6A5;
@@ -1902,6 +2133,14 @@ void mDE_mode_pallet_move(mDE_Ovl_c* design_ovl) {
     } else {
         design_ovl->_6BC = 4;
     }
+
+#ifdef MOUSE_INPUT
+    if (design_ovl->mouse_active) {
+        mDE_mode_pallet_mouse_move(design_ovl);
+        return;
+    }
+#endif
+
     mDE_judge_stick_nuetral(design_ovl);
     mDE_judge_stick_full(design_ovl);
     if (mDE_judge_stick(design_ovl)) {
@@ -1948,7 +2187,7 @@ void mDE_mode_pallet_move(mDE_Ovl_c* design_ovl) {
 }
 
 void mDE_mode_grid_move(mDE_Ovl_c* design_ovl) {
-    if (chkTrigger(BUTTON_A)) {
+    if (GET_BUTTON_PRESSED(BUTTON_A, 1 << 0)) {
         design_ovl->_69D = !design_ovl->_69D;
         if (design_ovl->_69D == FALSE) {
             sAdo_SysTrgStart(0x457);
@@ -1957,6 +2196,104 @@ void mDE_mode_grid_move(mDE_Ovl_c* design_ovl) {
         }
     }
 }
+
+#ifdef MOUSE_INPUT
+void mDE_mode_tool_mouse_move(mDE_Ovl_c* design_ovl) {   
+    int index_x = -1;
+    int index_y = -1;
+    f32 min_x_d, min_y_d, max_x_d, max_y_d = 0;
+    
+    const f32 base_y = 6.0f;
+    const f32 base_x = -122.0f;
+    const f32 step   = 24.0f;
+    
+    // Number of slots per row based on context
+    int slots_per_row[5];
+    if (Save_Get(scene_no) == SCENE_START_DEMO3 || GETREG(NMREG, 0x5f)) {
+        slots_per_row[0] = 3;  // Pen sizes
+        slots_per_row[1] = 6;  // Fill patterns
+        slots_per_row[2] = 5;  // Shape tools
+        slots_per_row[3] = 5;  // Stamps (kao 1-5)
+        slots_per_row[4] = 1;  // Undo
+    } else {
+        slots_per_row[0] = 3;  // Pen sizes
+        slots_per_row[1] = 6;  // Fill patterns
+        slots_per_row[2] = 5;  // Shape tools
+        slots_per_row[3] = 4;  // Stamps (heart, star, circle, square)
+        slots_per_row[4] = 1;  // Undo
+    }
+    
+    // Find which tool slot the mouse is over
+    for (int y = 0; y < 5; y++) {
+        f32 min_y = base_y - y * step;
+        f32 max_y = min_y + step;
+        
+        for (int x = 0; x < slots_per_row[y]; x++) {
+            f32 min_x = base_x + x * step;
+            f32 max_x = min_x + step;
+            
+            if (mDE_point_in_rect(design_ovl->centered_x, design_ovl->centered_y, 
+                                  min_x, min_y, max_x, max_y)) {
+                index_x = x;
+                index_y = y;
+                min_x_d = min_x;
+                min_y_d = min_y;
+                max_x_d = max_x;
+                max_y_d = max_y;
+                break;
+            }
+        }
+    }
+
+    // Update tool selection based on mouse hover
+    if (index_y != -1) {
+        u32 mouse_pressed = pc_mouse_button_pressed();
+
+        design_ovl->mouse_tool_active = 1;
+        if (design_ovl->mouse_tool_y != index_y || design_ovl->mouse_tool_x != index_x) {
+            design_ovl->mouse_tool_x = index_x;
+            design_ovl->mouse_tool_y = index_y;
+            sAdo_SysTrgStart(NA_SE_32);
+        }
+
+        // Handle click to select/activate tool
+        if (mouse_pressed & (1 << 0)) {
+            if (index_x > 0) design_ovl->mouse_tool_active = 0;
+            sAdo_SysTrgStart(NA_SE_33);
+            design_ovl->_69E = design_ovl->mouse_tool_x;
+            design_ovl->_69F = design_ovl->mouse_tool_y;
+            switch (index_y) {
+                case 0: // Pen tools
+                    design_ovl->_6A0 = index_x;
+                    mDE_main_mode_setup_action(design_ovl, mDE_MAIN_MODE_PEN);
+                    if (index_x > 0) mDE_setup_action(design_ovl, mDE_MODE_MAIN);
+                    break;
+                case 1: // Fill/Nuri tools
+                    design_ovl->_6A1 = index_x;
+                    mDE_main_mode_setup_action(design_ovl, mDE_MAIN_MODE_NURI);
+                    if (index_x > 0) mDE_setup_action(design_ovl, mDE_MODE_MAIN);
+                    break;
+                case 2: // Shape/Waku tools
+                    design_ovl->_6A2 = index_x;
+                    mDE_main_mode_setup_action(design_ovl, mDE_MAIN_MODE_WAKU);
+                    if (index_x > 0) mDE_setup_action(design_ovl, mDE_MODE_MAIN);
+                    break;
+                case 3: // Stamp/Mark tools
+                    design_ovl->_6A3 = index_x;
+                    mDE_main_mode_setup_action(design_ovl, mDE_MAIN_MODE_MARK);
+                    if (index_x > 0) mDE_setup_action(design_ovl, mDE_MODE_MAIN);
+                    break;
+                case 4: // Undo
+                    mDE_main_mode_setup_action(design_ovl, mDE_MAIN_MODE_UNDO);
+                    if (index_x > 0) mDE_setup_action(design_ovl, mDE_MODE_MAIN);
+                    break;
+            }
+        }
+    } else {
+        design_ovl->mouse_tool_active = 0;
+    }
+}
+#endif
 
 void mDE_mode_tool_move(mDE_Ovl_c* design_ovl) {
     design_ovl->move_pR = gamePT->mcon.move_pR;
@@ -1970,6 +2307,18 @@ void mDE_mode_tool_move(mDE_Ovl_c* design_ovl) {
     } else {
         design_ovl->_6BC = 8;
     }
+    
+#ifdef MOUSE_INPUT
+    if (design_ovl->mouse_active) {
+        mDE_mode_tool_mouse_move(design_ovl);
+        return;
+    }
+    if (design_ovl->mouse_tool_active) {
+        design_ovl->_69E = design_ovl->mouse_tool_x;
+        design_ovl->_69F = design_ovl->mouse_tool_y;
+        design_ovl->mouse_tool_active = 0;
+    }
+#endif
     mDE_judge_stick_nuetral(design_ovl);
     mDE_judge_stick_full(design_ovl);
     if (mDE_judge_stick(design_ovl)) {
@@ -2096,6 +2445,64 @@ void mDE_move_tool_decide(mDE_Ovl_c* design_ovl) {
 void mDE_move_Play(Submenu* submenu, mSM_MenuInfo_c* info) {
     u32 trigger = submenu->overlay->menu_control.trigger;
     mDE_Ovl_c* design_ovl = submenu->overlay->design_ovl;
+
+#ifdef MOUSE_INPUT
+    // Handle mouse movement for cursor
+    s32 mouse_x, mouse_y;
+    pc_mouse_get_native_position(&mouse_x, &mouse_y);
+    
+    // Set half position for interface
+    f32 ui_x = (f32)mouse_x * 0.5f;
+    f32 ui_y = (f32)mouse_y * 0.5f;
+    
+    // Convert from top-left origin (0,0) to centered origin (0,0 at center)
+    f32 centered_x = ui_x - 160.0f;
+    f32 centered_y = 120.0f - ui_y;
+    design_ovl->centered_x = centered_x;
+    design_ovl->centered_y = centered_y;
+
+    if (trigger) {
+        design_ovl->mouse_active = 0;
+    }
+    if (pc_mouse_active()) {
+        design_ovl->mouse_active = 1;
+    }
+
+    // Mode switching with mouse
+    if (design_ovl->mouse_active) {
+        u32 mouse_held = pc_mouse_button_held();
+        int holding_mouse = (
+            (((mouse_held >> 0) & 1 || (mouse_held >> 2) & 1) && design_ovl->mode == mDE_MODE_MAIN) || // Holding left/right click while drawing
+            ((design_ovl->_69A && design_ovl->_699 != 9) && design_ovl->mode == mDE_MAIN_MODE_WAKU) // Waku active selection
+        );
+
+        int new_mode = -1;
+        // Check each mode area (prioritize smaller areas first - tool and grid)
+        // Tool menu area (left side, tool selection)
+        if (mDE_point_in_rect(centered_x, centered_y, -122.0f, -93.0f, -97.0f, 27.0f) || design_ovl->mouse_tool_active) {
+            if (!holding_mouse) new_mode = mDE_MODE_TOOL;
+        }
+        // Grid toggle area
+        else if (mDE_point_in_rect(centered_x, centered_y, -126.0f, 47.0f, -92.0f, 80.0f)) {
+            if (!holding_mouse) new_mode = mDE_MODE_GRID;
+        }
+        // Palette area (right side)
+        else if (mDE_point_in_rect(centered_x, centered_y, 95.0f, -92.0f, 120.0f, 85.0f)) {
+            if (!holding_mouse) new_mode = mDE_MODE_PALLET;
+        }
+        // Main design area
+        else if (mDE_point_in_rect(centered_x, centered_y, -80.0f, -80.0f, 80.0f, 80.0f)) {
+            if (!holding_mouse) new_mode = mDE_MODE_MAIN;
+        }
+
+        // Switch mode if changed
+        if (new_mode != -1 && new_mode != design_ovl->mode) {
+            mDE_setup_action(design_ovl, new_mode);
+            sAdo_SysTrgStart(NA_SE_37);
+        }
+    }
+#endif
+
     if (submenu->current_menu_type == mSM_OVL_DESIGN) {
         if (trigger & BUTTON_START) {
             design_ovl->_698 = 0;
@@ -2316,7 +2723,14 @@ void mDE_set_frame_mark_dl(Submenu* submenu, GAME* game, mSM_MenuInfo_c* menu) {
     gSPDisplayList(POLY_OPA_DISP++, des_win_before);
     Matrix_push();
     if (design_ovl->mode == mDE_MODE_TOOL) {
-        Matrix_translate(-112.f + design_ovl->_69E * 0x18, 16.f - design_ovl->_69F * 0x18, 0.f, MTX_MULT);
+#ifdef MOUSE_INPUT
+        if (design_ovl->mouse_tool_active) { // Visual hover on mouse rather than actual selection
+            Matrix_translate(-112.f + design_ovl->mouse_tool_x * 0x18, 16.f - design_ovl->mouse_tool_y * 0x18, 0.f, MTX_MULT);
+        } else
+#endif
+        {
+            Matrix_translate(-112.f + design_ovl->_69E * 0x18, 16.f - design_ovl->_69F * 0x18, 0.f, MTX_MULT);
+        }
         gSPMatrix(POLY_OPA_DISP++, _Matrix_to_Mtx_new(graph), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 255, 185, 50, 50, 255);
     } else {
@@ -2678,6 +3092,16 @@ void mDE_design_ovl_init(Submenu* submenu) {
     design_ovl->_664 = -77.5f;
     design_ovl->cursor_x = 15;
     design_ovl->cursor_y = 15;
+#ifdef MOUSE_INPUT
+    design_ovl->mouse_active = 0;
+    design_ovl->centered_x = 0;
+    design_ovl->centered_y = 0;
+    design_ovl->mouse_tool_active = 0;
+    design_ovl->mouse_tool_x = 0;
+    design_ovl->mouse_tool_y = 0;
+    design_ovl->prev_cursor_x = -1;
+    design_ovl->prev_cursor_y = -1;
+#endif
     bcopy(&design_ovl->texture, &design_ovl->work_texture, sizeof(design_ovl->work_texture));
     osWritebackDCache(&design_ovl->work_texture, sizeof(design_ovl->work_texture));
     if (Save_Get(scene_no) == SCENE_START_DEMO3 || GETREG(NMREG, 0x5f)) {

--- a/src/game/m_hand_ovl.c
+++ b/src/game/m_hand_ovl.c
@@ -100,7 +100,7 @@ static void mHD_hand_pos_get(Submenu* submenu, f32* pos, int table_type, int tab
     }
 }
 
-static void mHD_hand_position_move(Submenu* submenu) {
+static void mHD_update_logical_position(Submenu* submenu) {
     mHD_Ovl_c* hand_ovl = submenu->overlay->hand_ovl;
     mTG_tag_c* tag = &submenu->overlay->tag_ovl->tags[0];
     int table_idx = submenu->overlay->tag_ovl->get_table_idx_proc(tag);
@@ -162,6 +162,51 @@ static void mHD_hand_position_move(Submenu* submenu) {
     } else {
         hand_ovl->info.move_flag = mHD_MOVE_NONE;
     }
+}
+
+static void mHD_update_visual_position(Submenu* submenu) {
+    mHD_Ovl_c* hand_ovl = submenu->overlay->hand_ovl;
+    mTG_Ovl_c* tag_ovl = submenu->overlay->tag_ovl;
+
+#ifdef MOUSE_INPUT
+    if (tag_ovl->mouse_active) {
+        f32 target_x = (tag_ovl->mouse_x - 160.0f);
+        f32 target_y = (120.0f - tag_ovl->mouse_y);
+        
+        f32 dX = target_x - hand_ovl->info.visual_pos[0];
+        f32 dY = target_y - hand_ovl->info.visual_pos[1];
+        
+        if (fabsf(dX) > 0.1f || fabsf(dY) > 0.1f) {
+            f32 speed = 0.3f;
+            hand_ovl->info.visual_pos[0] += dX * speed;
+            hand_ovl->info.visual_pos[1] += dY * speed;
+        } else {
+            hand_ovl->info.visual_pos[0] = target_x;
+            hand_ovl->info.visual_pos[1] = target_y;
+        }
+    } else
+#endif
+    {
+        f32 dX = hand_ovl->info.pos[0] - hand_ovl->info.visual_pos[0];
+        f32 dY = hand_ovl->info.pos[1] - hand_ovl->info.visual_pos[1];
+        
+        if (fabsf(dX) > 0.1f || fabsf(dY) > 0.1f) {
+            f32 speed = 0.3f;
+            hand_ovl->info.visual_pos[0] += dX * speed;
+            hand_ovl->info.visual_pos[1] += dY * speed;
+        } else {
+            hand_ovl->info.visual_pos[0] = hand_ovl->info.pos[0];
+            hand_ovl->info.visual_pos[1] = hand_ovl->info.pos[1];
+        }
+    }
+}
+
+static void mHD_hand_position_move(Submenu* submenu) {
+    /* Update logical position (what the game uses for item logic) */
+    mHD_update_logical_position(submenu);
+    
+    /* Update visual position (what we render) */
+    mHD_update_visual_position(submenu);
 }
 
 static void mHD_drop_item(Submenu* submenu, mTG_tag_c* tag, mActor_name_t* item, Mail_c* mail) {
@@ -981,10 +1026,11 @@ static void mHD_hand_ovl_draw(Submenu* submenu, GAME* game) {
         f32 pos_adj;
         mTG_tag_c* tag;
 
-        target_pos[0] =
-            (hand_ovl->info.pos[0] + hand_ovl->info.ofs[0] * cos_z + hand_ovl->info.ofs[1] * (-cos_x * sin_z)) + 4.0f;
-        target_pos[1] =
-            (hand_ovl->info.pos[1] + hand_ovl->info.ofs[0] * sin_z + hand_ovl->info.ofs[1] * (cos_x * cos_z)) - 4.0f;
+        /* Use visual_pos for rendering */
+        target_pos[0] = (hand_ovl->info.visual_pos[0] + hand_ovl->info.ofs[0] * cos_z + 
+                        hand_ovl->info.ofs[1] * (-cos_x * sin_z)) + 4.0f;
+        target_pos[1] = (hand_ovl->info.visual_pos[1] + hand_ovl->info.ofs[0] * sin_z + 
+                        hand_ovl->info.ofs[1] * (cos_x * cos_z)) - 4.0f;
 
         /* Draw hand shadow first */
         Matrix_push();
@@ -1072,6 +1118,9 @@ extern void mHD_hand_ovl_construct(Submenu* submenu) {
     mMl_clear_mail(&hand_ovl->info.mail);
     hand_ovl->info.item_cond = mPr_ITEM_COND_NORMAL;
 
+    hand_ovl->info.visual_pos[0] = 0.0f;
+    hand_ovl->info.visual_pos[1] = 0.0f;
+ 
     if (menu_info->menu_type == mSM_OVL_INVENTORY && menu_info->data0 == mSM_IV_OPEN_EXCHANGE) {
         mActor_name_t item;
         int item_cond;

--- a/src/game/m_tag_ovl.c
+++ b/src/game/m_tag_ovl.c
@@ -7999,11 +7999,426 @@ static int mTG_normal_move(Submenu* submenu, mSM_MenuInfo_c* menu_info, mTG_Ovl_
     return FALSE;
 }
 
+#ifdef MOUSE_INPUT
+typedef struct tag_table_mouse_data_s {
+    s16* col_mouse_pos;      // X positions for mouse selection (if NULL, use default col_pos)
+    s16* line_mouse_pos;     // Y positions for mouse selection (if NULL, use default row_pos)
+    s16* col_mouse_hitbox;   // Half-width hitbox per column (if NULL, use default 10.0f)
+    s16* line_mouse_hitbox;  // Half-height hitbox per row (if NULL, use default 10.0f)
+} mTG_table_mouse_data_c;
+
+// mTG_TABLE_MONEY
+static s16 mTG_money_col_mouse_pos[] = { 0 };
+static s16 mTG_money_line_mouse_pos[] = { 11 };
+static s16 mTG_item_col_hitbox[] = { 20 };
+static s16 mTG_item_line_hitbox[] = { 5 };
+
+// mTG_TABLE_PLAYER
+static s16 mTG_player_col_mouse_pos[] = { -78 };
+static s16 mTG_player_line_mouse_pos[] = { 45 };
+static s16 mTG_player_col_hitbox[] = { 22 };
+static s16 mTG_player_line_hitbox[] = { 20 };
+
+// mTG_TABLE_CPMAIL_TI
+static s16 mTG_cpmail_ti_col_hitbox[] = { 58 };
+
+// mTG_TABLE_CATALOG
+static s16 mTG_catalog_col_mouse_pos[] = { 10 };
+static s16 mTG_catalog_col_hitbox[] = { 55 };
+
+// mTG_TABLE_NEEDLEWORK
+static s16 mTG_needlework_col_hitbox[] = { 15, 15 };
+static s16 mTG_needlework_line_hitbox[] = { 15, 15, 15, 15 };
+
+// mTG_TABLE_CPORIGINAL_TI
+static s16 mTG_cporiginal_ti_col_hitbox[] = { 58 };
+
+// Table mouse data array
+static mTG_table_mouse_data_c mTG_table_mouse_data[] = {
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_ITEM (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_MAIL (default)
+    { mTG_money_col_mouse_pos, mTG_money_line_mouse_pos, mTG_item_col_hitbox, mTG_item_line_hitbox }, // mTG_TABLE_MONEY
+    { mTG_player_col_mouse_pos, mTG_player_line_mouse_pos, mTG_player_col_hitbox, mTG_player_line_hitbox }, // mTG_TABLE_PLAYER
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_BG (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_MBOX (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_HANIWA (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_COLLECT (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_WCHANGE (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CPMAIL (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CPMAIL_WC (default)
+    { NULL, NULL, mTG_cpmail_ti_col_hitbox, NULL }, // mTG_TABLE_CPMAIL_TI
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CPEDIT (stub)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CPEDIT_END (stub)
+    { mTG_catalog_col_mouse_pos, NULL, mTG_catalog_col_hitbox, NULL }, // mTG_TABLE_CATALOG
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CATALOG_WC (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_MUSIC_MAIN (default)
+    { NULL, NULL, mTG_needlework_col_hitbox, mTG_needlework_line_hitbox }, // mTG_TABLE_NEEDLEWORK
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CPORIGINAL (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_INVENTORY_WC_ORG (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CPORIGINAL_NW (default)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CPORIGINAL_WC (default)
+    { NULL, NULL, mTG_cporiginal_ti_col_hitbox, NULL }, // mTG_TABLE_CPORIGINAL_TI
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_GBA (stub)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_GBA_NW (stub)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CARD (stub)
+    { NULL, NULL, NULL, NULL }, // mTG_TABLE_CARD_NW (stub)
+};
+
+static void mTG_get_mouse_slot_pos(Submenu* submenu, f32* pos, int table, int idx, mTG_table_mouse_data_c* mouse_data) {
+    mTG_tag_data_table_c* data_p = &mTG_table_data[table];
+    int col = idx % data_p->col_num;
+    int row = idx / data_p->col_num;
+    f32 pos_x;
+    f32 pos_y;
+    
+    // Use mouse-specific X position if available, otherwise use default
+    if (mouse_data->col_mouse_pos != NULL) {
+        pos_x = mouse_data->col_mouse_pos[col];
+    } else {
+        pos_x = data_p->col_pos[col];
+    }
+    
+    // Use mouse-specific Y position if available, otherwise use default
+    if (mouse_data->line_mouse_pos != NULL) {
+        pos_y = mouse_data->line_mouse_pos[row];
+    } else {
+        pos_y = data_p->row_pos[row];
+    }
+    
+    f32 ofs = mTG_set_hand_pos_offset(submenu, table);
+    pos[0] = pos_x + ofs;
+    pos[1] = pos_y;
+}
+
+static void mTG_mouse_move_func(Submenu* submenu, mSM_MenuInfo_c* menu_info) {
+    mTG_Ovl_c* tag_ovl = submenu->overlay->tag_ovl;
+    mTG_tag_c* tag = &tag_ovl->tags[tag_ovl->sel_tag_idx];
+
+    /* Setup mouse logic */
+    s32 mouse_x, mouse_y;
+    pc_mouse_get_native_position(&mouse_x, &mouse_y);
+    f32 logical_mouse_x = mouse_x * 0.5;
+    f32 logical_mouse_y = mouse_y * 0.5;
+
+    u32 mouse_pressed = pc_mouse_button_pressed();
+    s32 mouse_wheel = pc_mouse_scroll_wheel();
+    s32 mouse_moved = pc_mouse_moved();
+
+    /* Controller and mouse active checks */
+    if (submenu->overlay->menu_control.trigger) {
+        tag_ovl->mouse_active = 0;
+    }
+    if (mouse_moved || mouse_pressed || mouse_wheel != 0) {
+        tag_ovl->mouse_active = 1;
+    }
+
+    tag_ovl->mouse_x = logical_mouse_x;
+    tag_ovl->mouse_y = logical_mouse_y;
+
+    if (!tag_ovl->mouse_active) {
+        return;
+    }
+
+    /* Mouse scroll wheel logic */
+    if (mouse_wheel != 0 && tag_ovl->sel_tag_idx == 0) {
+        if (tag_ovl->hovered_table == mTG_TABLE_CATALOG) {
+            mCL_Ovl_c* catalog_ovl = submenu->overlay->catalog_ovl;
+            mCL_Menu_c* catalog_menu = &catalog_ovl->menu_data[catalog_ovl->page_order[0]];
+
+            if (mouse_wheel > 0) {  // Scroll up
+                if (catalog_menu->top_idx != 0) {
+                    catalog_menu->top_idx--;
+                    catalog_ovl->change_flag = TRUE;
+                    sAdo_SysTrgStart(NA_SE_CURSOL);
+                }
+            } else {  // Scroll down
+                if (catalog_menu->top_idx + mCL_MENU_PAGE_SIZE < catalog_menu->item_count) {
+                    catalog_menu->top_idx++;
+                    catalog_ovl->change_flag = TRUE;
+                    sAdo_SysTrgStart(NA_SE_CURSOL);
+                }
+            }
+        }
+    }
+
+    /* Mouse movement logic */
+    if (mouse_moved) {
+        if (tag_ovl->sel_tag_idx == 0) {
+            f32 hand_x = (logical_mouse_x - 160.0f);
+            f32 hand_y = (120.0f - logical_mouse_y);
+
+            int hit_table = -1;
+            int hit_col = -1;
+            int hit_row = -1;
+
+            int tables_to_check[7];
+            int num_tables = 0;
+
+            // Determine which tables are active based on menu type
+            switch (menu_info->menu_type) {
+                case mSM_OVL_INVENTORY: // Pause inventory
+                    switch (menu_info->data0) {
+                        case mSM_IV_OPEN_NORMAL:
+                            if (submenu->overlay->inventory_ovl->page_order[0] == mIV_PAGE_INVENTORY) { // Main page inventory
+                                if (mTG_move_check_hand_item(submenu, mTG_TABLE_ITEM)) { // Items
+                                    tables_to_check[num_tables++] = mTG_TABLE_ITEM;
+                                }
+                                if (mTG_move_check_hand_item(submenu, mTG_TABLE_MAIL)) { // Letters
+                                    tables_to_check[num_tables++] = mTG_TABLE_MAIL;
+                                }
+                                if (mTG_move_check_hand_item(submenu, mTG_TABLE_MONEY)) { // Bells
+                                    tables_to_check[num_tables++] = mTG_TABLE_MONEY;
+                                }
+                                if (mTG_move_check_hand_item(submenu, mTG_TABLE_PLAYER)) { // Player
+                                    tables_to_check[num_tables++] = mTG_TABLE_PLAYER;
+                                }
+                                if (mTG_move_check_hand_item(submenu, mTG_TABLE_BG)) { // Background color change
+                                    tables_to_check[num_tables++] = mTG_TABLE_BG;
+                                }
+                                if (mTG_check_hand_condition(submenu)) { // Right labels (Fish, Inventory, Bugs)
+                                    tables_to_check[num_tables++] = mTG_TABLE_WCHANGE;
+                                }
+                                if (mTG_check_hand_condition(submenu)) { // Left label (Pattern clothes)
+                                    tables_to_check[num_tables++] = mTG_TABLE_INVENTORY_WC_ORG;
+                                }
+                            } else { // collection page (fish/bugs)
+                                tables_to_check[num_tables++] = mTG_TABLE_COLLECT;  // Fish/Bugs
+                                tables_to_check[num_tables++] = mTG_TABLE_WCHANGE;
+                            }
+                            break;
+                        case mSM_IV_OPEN_SEND_MAIL:
+                            tables_to_check[num_tables++] = mTG_TABLE_MAIL;
+                            break;
+                        default:
+                            tables_to_check[num_tables++] = mTG_TABLE_ITEM;
+                            break;
+                    }
+                    break;
+                case mSM_OVL_HANIWA: // Gyroid storage
+                    tables_to_check[num_tables++] = mTG_TABLE_HANIWA; // Gyroid top items
+                    tables_to_check[num_tables++] = mTG_TABLE_ITEM;
+                    break;
+                case mSM_OVL_CATALOG: // Tom Nook shop catalog
+                    tables_to_check[num_tables++] = mTG_TABLE_CATALOG;    // Catalog list
+                    tables_to_check[num_tables++] = mTG_TABLE_CATALOG_WC; // Right label (Catalog tabs)
+                    break;
+                case mSM_OVL_MAILBOX: // Mailbox
+                    tables_to_check[num_tables++] = mTG_TABLE_MBOX;  // Mailbox list
+                    tables_to_check[num_tables++] = mTG_TABLE_MAIL;  
+                    break;
+                case mSM_OVL_CPMAIL: // Post office save letter
+                    tables_to_check[num_tables++] = mTG_TABLE_MAIL;
+                    tables_to_check[num_tables++] = mTG_TABLE_CPMAIL;    // Letters saved
+                    tables_to_check[num_tables++] = mTG_TABLE_CPMAIL_TI; // Letter menu title
+                    tables_to_check[num_tables++] = mTG_TABLE_CPMAIL_WC; // Right label (Letter color tag)
+                    break;
+                case mSM_OVL_NEEDLEWORK: // Pattern menu
+                    tables_to_check[num_tables++] = mTG_TABLE_NEEDLEWORK;  // Pattern labels
+                    break;
+                case mSM_OVL_MUSIC: // Music box menu
+                    tables_to_check[num_tables++] = mTG_TABLE_MUSIC_MAIN;  // Music box list
+                    break;
+                case mSM_OVL_CPORIGINAL: // Save pattern menu
+                    tables_to_check[num_tables++] = mTG_TABLE_CPORIGINAL;    // Patterns saved
+                    tables_to_check[num_tables++] = mTG_TABLE_CPORIGINAL_NW; // Left label (patterns created)
+                    tables_to_check[num_tables++] = mTG_TABLE_CPORIGINAL_WC; // Right label (pattern color tag)
+                    tables_to_check[num_tables++] = mTG_TABLE_CPORIGINAL_TI; // Pattern menu title
+                    break;
+                case mSM_OVL_CPEDIT:  // N64 controller pak menu
+                    // This submenu is stubbed in GC, just here for convenience
+                    tables_to_check[num_tables++] = mTG_TABLE_CPEDIT;
+                    tables_to_check[num_tables++] = mTG_TABLE_CPEDIT_END;
+                    break;
+                case mSM_OVL_GBA:  // GBA menu
+                    // Port doesn't support gba connectivity but again, convenience
+                    switch (menu_info->data0) {
+                        case 3:
+                            tables_to_check[num_tables++] = mTG_TABLE_GBA;
+                            tables_to_check[num_tables++] = mTG_TABLE_GBA_NW;
+                            break;
+                        case 4:
+                            tables_to_check[num_tables++] = mTG_TABLE_CARD;
+                            tables_to_check[num_tables++] = mTG_TABLE_CARD_NW;
+                            break;
+                    }
+                    break;
+                default:
+                    // Just check the current table
+                    tables_to_check[num_tables++] = tag->table; 
+                    break;
+            }
+
+            for (int t = 0; t < num_tables; t++) {
+                int table = tables_to_check[t];
+                mTG_tag_data_table_c* data_p = &mTG_table_data[table];
+                mTG_table_mouse_data_c* mouse_data = &mTG_table_mouse_data[table];
+            
+                for (int row = 0; row < data_p->row_num; row++) {
+                    for (int col = 0; col < data_p->col_num; col++) {
+                        f32 slot_pos[2];
+                        mTG_get_mouse_slot_pos(submenu, slot_pos, table, row * data_p->col_num + col, mouse_data);
+                    
+                        // Get hitbox sizes, default to 10, commonly used for item cells
+                        f32 x_hitbox = 10.0f;
+                        f32 y_hitbox = 10.0f;
+                    
+                        if (mouse_data->col_mouse_hitbox != NULL) {
+                            x_hitbox = mouse_data->col_mouse_hitbox[col];
+                        }
+                        if (mouse_data->line_mouse_hitbox != NULL) {
+                            y_hitbox = mouse_data->line_mouse_hitbox[row];
+                        }
+                    
+                        // Rectangular hitbox check
+                        f32 dx = hand_x - slot_pos[0];
+                        f32 dy = hand_y - slot_pos[1];
+                    
+                        if (fabsf(dx) <= x_hitbox && fabsf(dy) <= y_hitbox) {
+                            hit_table = table;
+                            hit_col = col;
+                            hit_row = row;
+                        }
+                    }
+                }
+            }
+
+            if (hit_table >= 0) {
+                tag_ovl->hovered_table = hit_table;
+                tag_ovl->hovered_col = hit_col;
+                tag_ovl->hovered_row = hit_row;
+                tag_ovl->hovered_idx = hit_row * mTG_table_data[hit_table].col_num + hit_col;
+            } else {
+                tag_ovl->hovered_table = -1;
+                tag_ovl->hovered_col = -1;
+                tag_ovl->hovered_row = -1;
+                tag_ovl->hovered_idx = -1;
+            }
+
+            // Update cursor if we found a close slot and it's different from current
+            if (hit_table >= 0 && (hit_table != tag->table || 
+                hit_col != tag->tag_col || hit_row != tag->tag_row)) {
+
+                // Update the main tag to the hovered position
+                tag->table = hit_table;
+                tag->tag_col = hit_col;
+                tag->tag_row = hit_row;
+
+                if (hit_table == mTG_TABLE_CATALOG) {
+                    mCL_Ovl_c* catalog_ovl = submenu->overlay->catalog_ovl;
+                    catalog_ovl->change_flag = TRUE;
+                }
+
+                // Update hand position using the mouse position
+                int idx = hit_row * mTG_table_data[hit_table].col_num + hit_col;
+                mTG_set_hand_pos(submenu, tag->base_pos, hit_table, idx);
+
+                // Re-initialize the item window
+                mTG_init_tag_data_item_win(submenu);
+                sAdo_SysTrgStart(NA_SE_CURSOL);
+            }
+        } else {
+            // We're in a selection submenu - handle mouse over the options
+            mTG_tag_c* submenu_tag = &tag_ovl->tags[tag_ovl->sel_tag_idx];
+            mTG_tag_data_c* tag_data = &mTG_label_table[submenu_tag->type];
+
+            f32 scale = submenu_tag->scale;
+            f32 scale_rate = scale * 0.875f;
+
+            // Calculate the screen-space anchor for the text list
+            f32 tag_screen_x = 160.0f + (submenu_tag->base_pos[0] + menu_info->position[0] + 
+                scale * (submenu_tag->body_ofs[0] + submenu_tag->text_ofs[0]));
+            f32 tag_screen_y = 120.0f - (submenu_tag->base_pos[1] + menu_info->position[1] + 
+                scale * (submenu_tag->body_ofs[1] + submenu_tag->text_ofs[1]));
+
+            int hovered_option = -1;
+            f32 option_height = 16.0f * scale_rate; 
+
+            for (int i = 0; i < tag_data->lines; i++) {
+                // Set top and bottom option hitbox
+                f32 option_top = tag_screen_y + (i * option_height);
+                f32 option_bottom = option_top + option_height;
+
+                // Set horizontal - adjust width based on highlighted text 
+                int len = mMl_strlen(tag_data->words[i]->str, mTG_TAG_STR_LEN, CHAR_SPACE);
+                f32 option_width = mFont_GetStringWidth(tag_data->words[i]->str, len, TRUE) * scale_rate;
+
+                // Check if mouse_x/y (scaled/translated) falls within this rect
+                if ((tag_ovl->mouse_x >= tag_screen_x && tag_ovl->mouse_x <= (tag_screen_x + option_width)) &&
+                    (tag_ovl->mouse_y >= option_top && tag_ovl->mouse_y <= option_bottom)) {
+                    hovered_option = i;
+                    break;
+                }
+                
+            }
+
+            // Update cursor if hovering over a different option
+            if (hovered_option >= 0 && hovered_option != submenu_tag->tag_row) {
+                submenu_tag->tag_row = hovered_option;
+                sAdo_SysTrgStart(NA_SE_CURSOL);
+            }
+
+            tag_ovl->hovered_option = hovered_option;
+        }
+    }
+
+    /* Mouse click logic */
+    if (tag_ovl->sel_tag_idx == 0) {
+        if (tag_ovl->hovered_table >= 0) {
+            if (mouse_pressed & (1 << 0)) { // Left click
+                u32 old_trigger = submenu->overlay->menu_control.trigger;
+                submenu->overlay->menu_control.trigger = BUTTON_A;
+                mTG_move_decide(submenu, menu_info, tag);
+                submenu->overlay->menu_control.trigger = old_trigger;
+            }
+        }
+
+        if (mouse_pressed & (1 << 2)) { // Right click
+            u32 old_trigger = submenu->overlay->menu_control.trigger;
+            submenu->overlay->menu_control.trigger = BUTTON_B;
+            mTG_move_cancel(submenu, menu_info, tag);
+            submenu->overlay->menu_control.trigger = old_trigger;
+        }
+    } else {
+        if (tag_ovl->hovered_option >= 0) {
+            if (mouse_pressed & (1 << 0)) { // Left click
+                u32 old_trigger = submenu->overlay->menu_control.trigger;
+                submenu->overlay->menu_control.trigger = BUTTON_A;
+
+                mTG_tag_c* submenu_tag = &tag_ovl->tags[tag_ovl->sel_tag_idx];
+                mTG_label_table[submenu_tag->type].words[tag_ovl->hovered_option]->move_proc(submenu, menu_info);
+
+                submenu->overlay->menu_control.trigger = old_trigger;
+            }
+        }
+
+        if (mouse_pressed & (1 << 2)) { // Right click
+            u32 old_trigger = submenu->overlay->menu_control.trigger;
+            submenu->overlay->menu_control.trigger = BUTTON_B;
+
+            if (menu_info->menu_type == mSM_OVL_INVENTORY && menu_info->data0 == mSM_IV_OPEN_QUEST) {
+                mTG_close_window(submenu, menu_info, TRUE);
+            } else {
+                mTG_tag_c* last_tag = &tag_ovl->tags[tag_ovl->sel_tag_idx - 1];
+
+                mTG_return_tag_init(submenu, last_tag->type, mTG_RETURN_KEEP);
+                sAdo_SysTrgStart(MONO(NA_SE_3));
+            }
+
+            submenu->overlay->menu_control.trigger = old_trigger;
+        }
+    }
+}
+#endif
+
 static void mTG_move_func(Submenu* submenu, mSM_MenuInfo_c* menu_info) {
     mTG_Ovl_c* tag_ovl = submenu->overlay->tag_ovl;
     mTG_tag_c* tag = &tag_ovl->tags[tag_ovl->sel_tag_idx];
     mHD_Ovl_c* hand_ovl = submenu->overlay->hand_ovl;
     mIV_Ovl_c* inv_ovl = submenu->overlay->inventory_ovl;
+
+#ifdef MOUSE_INPUT
+    mTG_mouse_move_func(submenu, menu_info);
+#endif
 
     if (tag_ovl->sel_tag_idx < 0 || tag_ovl->sel_tag_idx >= mTG_TAG_NUM) {
         return;
@@ -8874,6 +9289,15 @@ extern void mTG_tag_ovl_construct(Submenu* submenu) {
 
         tag_ovl_p->sel_tag_idx = -1;
         tag_ovl_p->ret_tag_idx = -1;
+#ifdef MOUSE_INPUT
+        tag_ovl_p->mouse_active = 0;
+        tag_ovl_p->mouse_x = 160;
+        tag_ovl_p->mouse_y = 120;
+        tag_ovl_p->hovered_table = -1;
+        tag_ovl_p->hovered_idx = -1;
+        tag_ovl_p->hovered_col = -1;
+        tag_ovl_p->hovered_row = -1;
+#endif
     }
 }
 


### PR DESCRIPTION
Adds mouse support to most menu interfaces in the game, of which some makes sense logically.

Here's the changes in detail:

### m_hand (Hand cursor)

- Render now uses a separate visual position variable so mouse movement feels smooth.

### m_tag (Menu table like interface for items and selection entries for it)

- Each submenu has a table entry check for mouse to interact them seamlessly.
- Item selection entry highlights the text hovered by mouse.
- Left/Right click functionality for both table entries and item selection entry.
- Scroll wheel support for catalog list entries.
- Adjusted positions from some table entries and set hitboxes for each of them.

### m_design (Design menu)
- Seamlessly change design modes and it's entries depending where you hover the mouse.
- Interpolation used for pen drawing to prevent missed pixels if the mouse is moved too fast.
- Safety checks like preventing changing menus while currently drawing and extra spacing for tool menu icons.

### m_choice (Dialog choose selection)
- Simple hover and selection mouse support.