### PR TITLE
Add Discord Rich Presence support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Graphics settings are stored in `settings.ini` and can be edited manually or thr
 - MSAA (anti-aliasing)
 - Texture Loading/Caching (No need to enable if you aren't using a texture pack)
 
+## Discord Rich Presence
+
+Optional. To show your current town and location (e.g. "In the town of Foo" / "Inside Nook's Cranny") on your Discord profile, create a free Application at the [Discord Developer Portal](https://discord.com/developers/applications) and paste its Client ID into `discord_client_id` in `settings.ini`. Leave it blank to disable (default).
+
 ## Texture Packs
 
 Custom textures can be placed in `texture_pack/`. Dolphin-compatible format (XXHash64, DDS).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Graphics settings are stored in `settings.ini` and can be edited manually or thr
 
 ## Discord Rich Presence
 
-Optional. To show your current town and location (e.g. "In the town of Foo" / "Inside Nook's Cranny") on your Discord profile, create a free Application at the [Discord Developer Portal](https://discord.com/developers/applications) and paste its Client ID into `discord_client_id` in `settings.ini`. Leave it blank to disable (default).
+Optional, Windows builds only for now. To show your current town and location (e.g. "In the town of Foo" / "Inside Nook's Cranny") on your Discord profile, create a free Application at the [Discord Developer Portal](https://discord.com/developers/applications) and paste its Client ID into `discord_client_id` in `settings.ini`. Leave it blank to disable (default).
 
 ## Texture Packs
 

--- a/pc/CMakeLists.txt
+++ b/pc/CMakeLists.txt
@@ -298,6 +298,7 @@ set(PC_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_stubs_cpp.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_assets.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_disc.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/pc_discord.c
 )
 
 # =============================================================================

--- a/pc/include/pc_discord.h
+++ b/pc/include/pc_discord.h
@@ -1,0 +1,21 @@
+/* pc_discord.h - Discord Rich Presence (local IPC, best-effort) */
+#ifndef PC_DISCORD_H
+#define PC_DISCORD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* No-ops if settings.ini has no discord_client_id configured. */
+void pc_discord_init(void);
+
+/* Cheap to call every frame; internally throttled. */
+void pc_discord_update(void);
+
+void pc_discord_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PC_DISCORD_H */

--- a/pc/include/pc_settings.h
+++ b/pc/include/pc_settings.h
@@ -16,6 +16,7 @@ typedef struct {
     int disable_resetti;  /* 0=normal (Resetti appears on reset), 1=disable reset penalty */
     int nes_aspect;       /* NES emulator aspect: 0=fullscreen stretch, 1=4:3 pillarbox (default) */
     int master_volume;    /* Applied at the PC audio output, 0-100 (default 100) */
+    char discord_client_id[32]; /* Discord Application ID; empty disables Rich Presence */
 } PCSettings;
 
 #define PC_MAX_FPS_CAP 960

--- a/pc/src/pc_discord.c
+++ b/pc/src/pc_discord.c
@@ -1,0 +1,302 @@
+/* pc_discord.c - Discord Rich Presence over the local IPC named pipe.
+ *
+ * Implements just enough of Discord's documented RPC protocol (handshake +
+ * SET_ACTIVITY) to show what town/location the player is in. No official
+ * SDK or third-party library needed - it's a small JSON-over-named-pipe
+ * protocol: https://discord.com/developers/docs/topics/rpc
+ *
+ * All pipe I/O happens on a dedicated thread so a slow/absent Discord client
+ * can never stall the game's frame loop. The game thread only ever touches
+ * a small mutex-guarded "desired presence" struct.
+ *
+ * No-ops entirely if settings.ini has no discord_client_id (feature is
+ * opt-in; there's nothing to connect to without an Application ID from
+ * https://discord.com/developers/applications).
+ */
+#include "pc_platform.h"
+#include "pc_discord.h"
+#include "pc_settings.h"
+#include "m_common_data.h"
+#include "m_land.h"
+#include "m_scene_table.h"
+
+#ifdef _WIN32
+
+#define DISCORD_OP_HANDSHAKE 0
+#define DISCORD_OP_FRAME 1
+
+/* ~5s at 60fps: enough to feel live without spamming the pipe. */
+#define DISCORD_UPDATE_INTERVAL_FRAMES 300
+#define DISCORD_RECONNECT_DELAY_MS 5000
+
+typedef struct {
+    char details[128];
+    char state[128];
+    int has_state;
+    int version; /* bumped whenever details/state change */
+} pc_discord_presence_t;
+
+static SDL_Thread* s_thread = NULL;
+static SDL_atomic_t s_running;
+static SDL_mutex* s_mutex = NULL;
+static pc_discord_presence_t s_desired;
+static int s_sent_version = -1;
+static char s_client_id[32];
+static long long s_start_time = 0;
+static HANDLE s_pipe = INVALID_HANDLE_VALUE;
+
+static int pc_discord_connect(void) {
+    s_pipe = CreateFileA("\\\\.\\pipe\\discord-ipc-0", GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+    return s_pipe != INVALID_HANDLE_VALUE;
+}
+
+static void pc_discord_disconnect(void) {
+    if (s_pipe != INVALID_HANDLE_VALUE) {
+        CloseHandle(s_pipe);
+        s_pipe = INVALID_HANDLE_VALUE;
+    }
+}
+
+/* The pipe may be message-mode, where each WriteFile call is a distinct
+ * message. Header and payload must go in a single write or Discord's
+ * parser desyncs silently (writes still "succeed", nothing shows up). */
+static int pc_discord_send_frame(int opcode, const char* json, int len) {
+    char buf[8 + 512];
+    DWORD written;
+
+    if ((size_t)len > sizeof(buf) - 8) return 0;
+
+    ((int*)buf)[0] = opcode;
+    ((int*)buf)[1] = len;
+    memcpy(buf + 8, json, (size_t)len);
+
+    if (!WriteFile(s_pipe, buf, (DWORD)(8 + len), &written, NULL) || written != (DWORD)(8 + len)) {
+        return 0;
+    }
+    return 1;
+}
+
+/* Appends src to out[*pos..], backslash-escaping " and \. */
+static void json_escape_append(char* out, size_t out_size, size_t* pos, const char* src) {
+    for (; *src != '\0' && *pos + 2 < out_size; src++) {
+        if (*src == '"' || *src == '\\') {
+            out[(*pos)++] = '\\';
+        }
+        out[(*pos)++] = *src;
+    }
+}
+
+static int pc_discord_send_activity(const char* details, const char* state, int has_state) {
+    char json[512];
+    size_t pos;
+
+    pos = (size_t)snprintf(json, sizeof(json), "{\"cmd\":\"SET_ACTIVITY\",\"args\":{\"pid\":%lu,\"activity\":{\"details\":\"",
+                            (unsigned long)GetCurrentProcessId());
+    json_escape_append(json, sizeof(json), &pos, details);
+
+    if (has_state) {
+        pos += (size_t)snprintf(json + pos, sizeof(json) - pos, "\",\"state\":\"");
+        json_escape_append(json, sizeof(json), &pos, state);
+    }
+
+    /* "game_icon" only renders if the Discord Application has a Rich Presence
+     * art asset uploaded under that exact key (Developer Portal > Rich
+     * Presence > Art Assets); otherwise Discord just drops it silently. */
+    pos += (size_t)snprintf(
+        json + pos, sizeof(json) - pos,
+        "\",\"timestamps\":{\"start\":%lld},\"assets\":{\"large_image\":\"game_icon\",\"large_text\":\"Animal Crossing\"}}},\"nonce\":\"1\"}",
+        s_start_time);
+
+    return pc_discord_send_frame(DISCORD_OP_FRAME, json, (int)pos);
+}
+
+static int pc_discord_handshake(void) {
+    char json[128];
+    int len = snprintf(json, sizeof(json), "{\"v\":1,\"client_id\":\"%s\"}", s_client_id);
+    return pc_discord_send_frame(DISCORD_OP_HANDSHAKE, json, len);
+}
+
+static int pc_discord_worker(void* data) {
+    int connected = 0;
+    Uint32 next_connect_attempt = 0;
+    (void)data;
+
+    while (SDL_AtomicGet(&s_running)) {
+        if (!connected) {
+            Uint32 now = SDL_GetTicks();
+            if (now >= next_connect_attempt) {
+                if (pc_discord_connect() && pc_discord_handshake()) {
+                    connected = 1;
+                    s_sent_version = -1; /* force a resend now that we're connected */
+                    if (g_pc_verbose) printf("[Discord] Connected to Discord IPC\n");
+                } else {
+                    pc_discord_disconnect();
+                    next_connect_attempt = now + DISCORD_RECONNECT_DELAY_MS;
+                }
+            }
+        }
+
+        if (connected) {
+            pc_discord_presence_t local;
+            SDL_LockMutex(s_mutex);
+            local = s_desired;
+            SDL_UnlockMutex(s_mutex);
+
+            if (local.version != s_sent_version) {
+                if (!pc_discord_send_activity(local.details, local.state, local.has_state)) {
+                    if (g_pc_verbose) printf("[Discord] Lost connection to Discord\n");
+                    pc_discord_disconnect();
+                    connected = 0;
+                    next_connect_attempt = SDL_GetTicks() + DISCORD_RECONNECT_DELAY_MS;
+                } else {
+                    s_sent_version = local.version;
+                }
+            }
+        }
+
+        SDL_Delay(250);
+    }
+
+    pc_discord_disconnect();
+    return 0;
+}
+
+void pc_discord_init(void) {
+    strncpy(s_client_id, g_pc_settings.discord_client_id, sizeof(s_client_id) - 1);
+    s_client_id[sizeof(s_client_id) - 1] = '\0';
+
+    if (s_client_id[0] == '\0') {
+        return; /* feature disabled: no client ID configured in settings.ini */
+    }
+
+    s_start_time = (long long)time(NULL);
+    s_mutex = SDL_CreateMutex();
+    if (!s_mutex) {
+        printf("[Discord] Failed to create mutex: %s\n", SDL_GetError());
+        return;
+    }
+
+    memset(&s_desired, 0, sizeof(s_desired));
+    snprintf(s_desired.details, sizeof(s_desired.details), "Playing Animal Crossing");
+
+    SDL_AtomicSet(&s_running, 1);
+    s_thread = SDL_CreateThread(pc_discord_worker, "DiscordRPC", NULL);
+    if (!s_thread) {
+        printf("[Discord] Failed to create worker thread: %s\n", SDL_GetError());
+        SDL_AtomicSet(&s_running, 0);
+    }
+}
+
+/* Town names use the game's own font character codes, which only line up
+ * with ASCII across these two ranges (checked against m_font.h); everything
+ * else (accented letters, symbols) is dropped rather than shown wrong. */
+static int pc_discord_char_is_ascii(u8 c) {
+    return (c >= 32 && c <= 90) || (c >= 97 && c <= 122);
+}
+
+static void pc_discord_get_town_name(char* out, size_t out_size) {
+    u8* raw = mLd_GetLandName();
+    size_t len = 0;
+    int i;
+
+    for (i = 0; i < LAND_NAME_SIZE && len + 1 < out_size; i++) {
+        if (pc_discord_char_is_ascii(raw[i])) {
+            out[len++] = (char)raw[i];
+        }
+    }
+    while (len > 0 && out[len - 1] == ' ') len--;
+    out[len] = '\0';
+}
+
+static const char* pc_discord_location_for_scene(int scene_no) {
+    switch (scene_no) {
+        case SCENE_FG: return "Outside";
+        case SCENE_SHOP0: return "Inside Nook's Cranny";
+        case SCENE_BROKER_SHOP: return "Inside Crazy Redd's tent";
+        case SCENE_POST_OFFICE: return "Inside the Post Office";
+        case SCENE_POLICE_BOX: return "Inside the Police Station";
+        case SCENE_CONVENI: return "Inside Nook 'n' Go";
+        case SCENE_SUPER: return "Inside Nookway";
+        case SCENE_DEPART:
+        case SCENE_DEPART_2: return "Inside Nookington's";
+        case SCENE_NEEDLEWORK: return "Inside Able Sisters";
+        case SCENE_NPC_HOUSE:
+        case SCENE_COTTAGE_NPC: return "Visiting a neighbor's house";
+        case SCENE_MY_ROOM_S:
+        case SCENE_MY_ROOM_M:
+        case SCENE_MY_ROOM_L:
+        case SCENE_MY_ROOM_LL1:
+        case SCENE_MY_ROOM_LL2:
+        case SCENE_MY_ROOM_BASEMENT_S:
+        case SCENE_MY_ROOM_BASEMENT_M:
+        case SCENE_MY_ROOM_BASEMENT_L:
+        case SCENE_MY_ROOM_BASEMENT_LL1:
+        case SCENE_COTTAGE_MY: return "At home";
+        default:
+            if (mSc_IS_SCENE_MUSEUM_ROOM(scene_no)) return "At the Museum";
+            return NULL; /* menus, demos, and scenes we're not confident labeling */
+    }
+}
+
+void pc_discord_update(void) {
+    static u32 frame = 0;
+    char details[128];
+    char state[128];
+    int has_state = 0;
+
+    if (!s_mutex) return; /* not initialized (no client ID configured) */
+
+    frame++;
+    if (frame % DISCORD_UPDATE_INTERVAL_FRAMES != 0) return;
+
+    if (!pc_save_loaded) {
+        snprintf(details, sizeof(details), "Playing Animal Crossing");
+    } else {
+        char town[32];
+        pc_discord_get_town_name(town, sizeof(town));
+
+        if (town[0] == '\0') {
+            snprintf(details, sizeof(details), "Playing Animal Crossing");
+        } else {
+            const char* loc;
+
+            snprintf(details, sizeof(details), "In the town of %s", town);
+
+            loc = pc_discord_location_for_scene(Save_Get(scene_no));
+            if (loc) {
+                snprintf(state, sizeof(state), "%s", loc);
+                has_state = 1;
+            }
+        }
+    }
+
+    SDL_LockMutex(s_mutex);
+    if (strcmp(s_desired.details, details) != 0 || s_desired.has_state != has_state ||
+        (has_state && strcmp(s_desired.state, state) != 0)) {
+        snprintf(s_desired.details, sizeof(s_desired.details), "%s", details);
+        s_desired.has_state = has_state;
+        if (has_state) snprintf(s_desired.state, sizeof(s_desired.state), "%s", state);
+        s_desired.version++;
+    }
+    SDL_UnlockMutex(s_mutex);
+}
+
+void pc_discord_shutdown(void) {
+    if (!s_mutex) return;
+
+    SDL_AtomicSet(&s_running, 0);
+    if (s_thread) {
+        SDL_WaitThread(s_thread, NULL);
+        s_thread = NULL;
+    }
+    SDL_DestroyMutex(s_mutex);
+    s_mutex = NULL;
+}
+
+#else /* !_WIN32 */
+
+void pc_discord_init(void) {}
+void pc_discord_update(void) {}
+void pc_discord_shutdown(void) {}
+
+#endif

--- a/pc/src/pc_discord.c
+++ b/pc/src/pc_discord.c
@@ -17,6 +17,7 @@
 #include "pc_discord.h"
 #include "pc_settings.h"
 #include "m_common_data.h"
+#include "m_font.h"
 #include "m_land.h"
 #include "m_scene_table.h"
 
@@ -25,15 +26,18 @@
 #define DISCORD_OP_HANDSHAKE 0
 #define DISCORD_OP_FRAME 1
 
-/* ~5s at 60fps: enough to feel live without spamming the pipe. */
-#define DISCORD_UPDATE_INTERVAL_FRAMES 300
+/* Enough to feel live without spamming the pipe (Discord rate-limits
+ * presence updates to roughly one per 15s anyway). */
+#define DISCORD_UPDATE_INTERVAL_MS 5000
 #define DISCORD_RECONNECT_DELAY_MS 5000
+
+/* Default when no save is loaded or the town has no printable name. */
+static const char DEFAULT_DETAILS[] = "Playing Animal Crossing";
 
 typedef struct {
     char details[128];
-    char state[128];
-    int has_state;
-    int version; /* bumped whenever details/state change */
+    char state[128]; /* "" = no state line */
+    int version;     /* bumped whenever details/state change */
 } pc_discord_presence_t;
 
 static SDL_Thread* s_thread = NULL;
@@ -45,9 +49,21 @@ static char s_client_id[32];
 static long long s_start_time = 0;
 static HANDLE s_pipe = INVALID_HANDLE_VALUE;
 
+/* Discord (or another RPC app) may hold any of discord-ipc-0..9; with
+ * multiple clients running (e.g. stable + Canary) the active one is often
+ * not on -0, so probe all ten. */
 static int pc_discord_connect(void) {
-    s_pipe = CreateFileA("\\\\.\\pipe\\discord-ipc-0", GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
-    return s_pipe != INVALID_HANDLE_VALUE;
+    char pipe_name[32];
+    int i;
+
+    for (i = 0; i <= 9; i++) {
+        snprintf(pipe_name, sizeof(pipe_name), "\\\\.\\pipe\\discord-ipc-%d", i);
+        s_pipe = CreateFileA(pipe_name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+        if (s_pipe != INVALID_HANDLE_VALUE) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 static void pc_discord_disconnect(void) {
@@ -86,26 +102,38 @@ static void json_escape_append(char* out, size_t out_size, size_t* pos, const ch
     }
 }
 
-static int pc_discord_send_activity(const char* details, const char* state, int has_state) {
+/* snprintf returns the would-be length when it truncates; clamp so pos
+ * stays a valid offset and sizeof(json) - pos can't underflow. */
+static size_t clamp_pos(size_t pos, size_t size) {
+    return pos < size ? pos : size - 1;
+}
+
+/* state may be "" to omit the state line entirely. */
+static int pc_discord_send_activity(const char* details, const char* state) {
     char json[512];
     size_t pos;
 
-    pos = (size_t)snprintf(json, sizeof(json), "{\"cmd\":\"SET_ACTIVITY\",\"args\":{\"pid\":%lu,\"activity\":{\"details\":\"",
-                            (unsigned long)GetCurrentProcessId());
+    pos = (size_t)snprintf(json, sizeof(json),
+                           "{\"cmd\":\"SET_ACTIVITY\",\"args\":{\"pid\":%lu,\"activity\":{\"details\":\"",
+                           (unsigned long)GetCurrentProcessId());
+    pos = clamp_pos(pos, sizeof(json));
     json_escape_append(json, sizeof(json), &pos, details);
 
-    if (has_state) {
+    if (state[0] != '\0') {
         pos += (size_t)snprintf(json + pos, sizeof(json) - pos, "\",\"state\":\"");
+        pos = clamp_pos(pos, sizeof(json));
         json_escape_append(json, sizeof(json), &pos, state);
     }
 
     /* "game_icon" only renders if the Discord Application has a Rich Presence
      * art asset uploaded under that exact key (Developer Portal > Rich
      * Presence > Art Assets); otherwise Discord just drops it silently. */
-    pos += (size_t)snprintf(
-        json + pos, sizeof(json) - pos,
-        "\",\"timestamps\":{\"start\":%lld},\"assets\":{\"large_image\":\"game_icon\",\"large_text\":\"Animal Crossing\"}}},\"nonce\":\"1\"}",
-        s_start_time);
+    pos += (size_t)snprintf(json + pos, sizeof(json) - pos,
+                            "\",\"timestamps\":{\"start\":%lld},"
+                            "\"assets\":{\"large_image\":\"game_icon\",\"large_text\":\"Animal Crossing\"}}},"
+                            "\"nonce\":\"1\"}",
+                            s_start_time);
+    pos = clamp_pos(pos, sizeof(json));
 
     return pc_discord_send_frame(DISCORD_OP_FRAME, json, (int)pos);
 }
@@ -124,7 +152,8 @@ static int pc_discord_worker(void* data) {
     while (SDL_AtomicGet(&s_running)) {
         if (!connected) {
             Uint32 now = SDL_GetTicks();
-            if (now >= next_connect_attempt) {
+            /* signed diff is safe across the Uint32 tick wraparound */
+            if ((Sint32)(now - next_connect_attempt) >= 0) {
                 if (pc_discord_connect() && pc_discord_handshake()) {
                     connected = 1;
                     s_sent_version = -1; /* force a resend now that we're connected */
@@ -143,7 +172,7 @@ static int pc_discord_worker(void* data) {
             SDL_UnlockMutex(s_mutex);
 
             if (local.version != s_sent_version) {
-                if (!pc_discord_send_activity(local.details, local.state, local.has_state)) {
+                if (!pc_discord_send_activity(local.details, local.state)) {
                     if (g_pc_verbose) printf("[Discord] Lost connection to Discord\n");
                     pc_discord_disconnect();
                     connected = 0;
@@ -177,7 +206,7 @@ void pc_discord_init(void) {
     }
 
     memset(&s_desired, 0, sizeof(s_desired));
-    snprintf(s_desired.details, sizeof(s_desired.details), "Playing Animal Crossing");
+    snprintf(s_desired.details, sizeof(s_desired.details), "%s", DEFAULT_DETAILS);
 
     SDL_AtomicSet(&s_running, 1);
     s_thread = SDL_CreateThread(pc_discord_worker, "DiscordRPC", NULL);
@@ -187,11 +216,31 @@ void pc_discord_init(void) {
     }
 }
 
-/* Town names use the game's own font character codes, which only line up
- * with ASCII across these two ranges (checked against m_font.h); everything
- * else (accented letters, symbols) is dropped rather than shown wrong. */
-static int pc_discord_char_is_ascii(u8 c) {
-    return (c >= 32 && c <= 90) || (c >= 97 && c <= 122);
+/* Town names use the game's own font character codes. The 32..122 block
+ * mostly coincides with ASCII, but a handful of codes in it are game
+ * symbols or accented letters (see m_font.h): those map to a base letter
+ * where one exists and are dropped ('\0') otherwise. */
+static char pc_discord_font_to_ascii(u8 c) {
+    switch (c) {
+        case CHAR_ACUTE_a:
+        case CHAR_CIRCUMFLEX_a:
+        case CHAR_TILDE_a:
+        case CHAR_DIARESIS_a:
+        case CHAR_ANGSTROM_a:
+            return 'a';
+        case CHAR_TILDE:
+            return '~';
+        case CHAR_SYMBOL_HEART:
+        case CHAR_SYMBOL_MUSIC_NOTE:
+        case CHAR_SYMBOL_DROPLET:
+        case CHAR_SYMBOL_ANNOYED:
+            return '\0';
+        default:
+            if ((c >= CHAR_SPACE && c <= CHAR_UNDERSCORE) || (c >= CHAR_a && c <= CHAR_z)) {
+                return (char)c; /* these font codes coincide with ASCII */
+            }
+            return '\0';
+    }
 }
 
 static void pc_discord_get_town_name(char* out, size_t out_size) {
@@ -200,8 +249,9 @@ static void pc_discord_get_town_name(char* out, size_t out_size) {
     int i;
 
     for (i = 0; i < LAND_NAME_SIZE && len + 1 < out_size; i++) {
-        if (pc_discord_char_is_ascii(raw[i])) {
-            out[len++] = (char)raw[i];
+        char c = pc_discord_font_to_ascii(raw[i]);
+        if (c != '\0') {
+            out[len++] = c;
         }
     }
     while (len > 0 && out[len - 1] == ' ') len--;
@@ -239,43 +289,39 @@ static const char* pc_discord_location_for_scene(int scene_no) {
 }
 
 void pc_discord_update(void) {
-    static u32 frame = 0;
+    static Uint32 next_update = 0;
     char details[128];
-    char state[128];
-    int has_state = 0;
+    char state[128] = "";
+    Uint32 now;
 
     if (!s_mutex) return; /* not initialized (no client ID configured) */
 
-    frame++;
-    if (frame % DISCORD_UPDATE_INTERVAL_FRAMES != 0) return;
+    /* Wall-clock throttle (frame counting would scale with the FPS cap).
+     * next_update == 0 fires immediately on the first call; the signed
+     * diff is safe across the Uint32 tick wraparound. */
+    now = SDL_GetTicks();
+    if (next_update != 0 && (Sint32)(now - next_update) < 0) return;
+    next_update = now + DISCORD_UPDATE_INTERVAL_MS;
 
-    if (!pc_save_loaded) {
-        snprintf(details, sizeof(details), "Playing Animal Crossing");
-    } else {
+    snprintf(details, sizeof(details), "%s", DEFAULT_DETAILS);
+    if (pc_save_loaded) {
         char town[32];
         pc_discord_get_town_name(town, sizeof(town));
 
-        if (town[0] == '\0') {
-            snprintf(details, sizeof(details), "Playing Animal Crossing");
-        } else {
-            const char* loc;
+        if (town[0] != '\0') {
+            const char* loc = pc_discord_location_for_scene(Save_Get(scene_no));
 
             snprintf(details, sizeof(details), "In the town of %s", town);
-
-            loc = pc_discord_location_for_scene(Save_Get(scene_no));
             if (loc) {
                 snprintf(state, sizeof(state), "%s", loc);
-                has_state = 1;
             }
         }
     }
 
     SDL_LockMutex(s_mutex);
-    if (strcmp(s_desired.details, details) != 0 || s_desired.has_state != has_state ||
-        (has_state && strcmp(s_desired.state, state) != 0)) {
+    if (strcmp(s_desired.details, details) != 0 || strcmp(s_desired.state, state) != 0) {
         snprintf(s_desired.details, sizeof(s_desired.details), "%s", details);
-        s_desired.has_state = has_state;
-        if (has_state) snprintf(s_desired.state, sizeof(s_desired.state), "%s", state);
+        snprintf(s_desired.state, sizeof(s_desired.state), "%s", state);
         s_desired.version++;
     }
     SDL_UnlockMutex(s_mutex);

--- a/pc/src/pc_main.c
+++ b/pc/src/pc_main.c
@@ -333,6 +333,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "[PC] %s\n", msg);
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
                                  "Animal Crossing - Missing ROM", msg, g_pc_window);
+        pc_discord_shutdown();
         pc_platform_shutdown();
         return 1;
     }

--- a/pc/src/pc_main.c
+++ b/pc/src/pc_main.c
@@ -8,6 +8,7 @@
 #include "pc_disc.h"
 #include "pc_typing.h"
 #include "pc_pause_menu.h"
+#include "pc_discord.h"
 #include "m_kankyo.h"
 
 /* prefer discrete GPU on laptops */
@@ -158,6 +159,7 @@ int pc_platform_poll_events(void) {
     SDL_Event event;
 
     pc_typing_update();
+    pc_discord_update();
 
     while (SDL_PollEvent(&event)) {
         switch (event.type) {
@@ -321,6 +323,7 @@ int main(int argc, char* argv[]) {
     pc_settings_load();
     pc_keybindings_load();
     pc_platform_init();
+    pc_discord_init();
     pc_disc_init();
     if (!pc_assets_init()) {
         const char* msg =
@@ -338,6 +341,7 @@ int main(int argc, char* argv[]) {
     boot_main(argc, (const char**)argv); /* full init → HotStartEntry → game loop */
 
     pc_disc_shutdown();
+    pc_discord_shutdown();
     pc_platform_shutdown();
     return 0;
 }

--- a/pc/src/pc_settings.c
+++ b/pc/src/pc_settings.c
@@ -13,6 +13,7 @@ PCSettings g_pc_settings = {
     .disable_resetti = 0,
     .nes_aspect = 1,
     .master_volume = 100,
+    .discord_client_id = "",
 };
 
 static const char* SETTINGS_FILE = "settings.ini";
@@ -48,7 +49,12 @@ static const char* DEFAULT_SETTINGS =
     "\n"
     "[Audio]\n"
     "# Master output volume as a percentage (0-100)\n"
-    "master_volume = 100\n";
+    "master_volume = 100\n"
+    "\n"
+    "[Discord]\n"
+    "# Discord Rich Presence: paste your Application's Client ID from\n"
+    "# https://discord.com/developers/applications to enable (leave blank to disable)\n"
+    "discord_client_id = \n";
 
 static const char* skip_ws(const char* s) {
     while (*s == ' ' || *s == '\t') s++;
@@ -89,6 +95,9 @@ static void apply_setting(const char* key, const char* value) {
         if (val == 0 || val == 1) g_pc_settings.nes_aspect = val;
     } else if (strcmp(key, "master_volume") == 0) {
         if (val >= 0 && val <= 100) g_pc_settings.master_volume = val;
+    } else if (strcmp(key, "discord_client_id") == 0) {
+        strncpy(g_pc_settings.discord_client_id, value, sizeof(g_pc_settings.discord_client_id) - 1);
+        g_pc_settings.discord_client_id[sizeof(g_pc_settings.discord_client_id) - 1] = '\0';
     }
 }
 
@@ -157,6 +166,11 @@ void pc_settings_save(void) {
     fprintf(f, "[Audio]\n");
     fprintf(f, "# Master output volume as a percentage (0-100)\n");
     fprintf(f, "master_volume = %d\n", g_pc_settings.master_volume);
+    fprintf(f, "\n");
+    fprintf(f, "[Discord]\n");
+    fprintf(f, "# Discord Rich Presence: paste your Application's Client ID from\n");
+    fprintf(f, "# https://discord.com/developers/applications to enable (leave blank to disable)\n");
+    fprintf(f, "discord_client_id = %s\n", g_pc_settings.discord_client_id);
     fclose(f);
     printf("[Settings] Saved %s\n", SETTINGS_FILE);
 }


### PR DESCRIPTION
Shows the player's town name and current location (e.g. "Inside Nook's Cranny") on Discord via the local IPC protocol, closing #78. Opt-in via a discord_client_id in settings.ini (blank disables it, the default). All pipe I/O runs on a dedicated thread so a slow or absent Discord client can never stall the game loop.