### PR TITLE
Quality of Life changes

### DIFF
--- a/include/m_private.h
+++ b/include/m_private.h
@@ -330,6 +330,12 @@ extern void mPr_RenewalMapInfo(mPr_map_info_c* map_info, int max, mLd_land_info_
 extern void mPr_RandomSetPlayerData_title_demo();
 extern void mPr_PrintMapInfo_debug(gfxprint_t* gfxprint);
 
+#ifdef PC_ENHANCEMENTS
+    /* new bells go straight to wallet */
+    extern u32 mPr_GetAmountForMoneyItem(mActor_name_t item);
+    extern int mPr_GivePossessionBells(u32 amount);
+#endif
+
 extern Private_c g_foreigner_private;
 
 #ifdef __cplusplus

--- a/pc/shaders/default.frag
+++ b/pc/shaders/default.frag
@@ -263,25 +263,6 @@ vec2 applyIndirect(ivec4 ind_cfg, ivec3 ind_wrap, vec2 coord,
     return wrappedCoord + offset;
 }
 
-// A nice trick to make large pixels on screen more pleasing to look at
-// Rather than interpolating over the entire pixel when drawing something linearly, only interpolate on the edges
-// this looks look a lot better when using the original GameCube graphics
-
-const float TEX_SHARP_PIXELS = 3.5; // lower is sharper
-
-vec4 sharpSample(sampler2D tex, vec2 uv) {
-    vec2 texSize = vec2(textureSize(tex, 0));
-    vec2 t = uv * texSize - 0.5;
-    vec2 i = floor(t);
-
-    vec2 halfWidth = clamp(0.5 * TEX_SHARP_PIXELS * fwidth(t), .00001, 0.5);
-
-    vec2 sharpFrac = clamp(((t-i) - (0.5 - halfWidth)) / (2.0 * halfWidth), 0.0, 1.0);
-
-    vec2 sharpUV = (i + sharpFrac + 0.5) / texSize;
-    return texture(tex, sharpUV);
-}
-
 /* EQUAL/NEQUAL use epsilon for float precision after interpolation */
 bool alphaTest(int comp, float val, float ref) {
     const float EPS = 0.5 / 255.0;
@@ -322,9 +303,9 @@ void main() {
     /* Texture samples. Kept as an explicit 3-way dispatch rather than a
        sampler array so the C side doesn't need to change. */
     vec4 texColor[3];
-    texColor[0] = (u_use_texture[0] != 0) ? sharpSample(u_texture0, stc[0]) : vec4(1.0);
-    texColor[1] = (u_use_texture[1] != 0) ? sharpSample(u_texture1, stc[1]) : vec4(1.0);
-    texColor[2] = (u_use_texture[2] != 0) ? sharpSample(u_texture2, stc[2]) : vec4(1.0);
+    texColor[0] = (u_use_texture[0] != 0) ? texture(u_texture0, stc[0]) : vec4(1.0);
+    texColor[1] = (u_use_texture[1] != 0) ? texture(u_texture1, stc[1]) : vec4(1.0);
+    texColor[2] = (u_use_texture[2] != 0) ? texture(u_texture2, stc[2]) : vec4(1.0);
 
     /* Rasterized color: GX lighting model */
     vec4 rasColor;

--- a/pc/shaders/default.frag
+++ b/pc/shaders/default.frag
@@ -267,7 +267,7 @@ vec2 applyIndirect(ivec4 ind_cfg, ivec3 ind_wrap, vec2 coord,
 // Rather than interpolating over the entire pixel when drawing something linearly, only interpolate on the edges
 // this looks look a lot better when using the original GameCube graphics
 
-const float TEX_SHARP_PIXELS = 5.0;
+const float TEX_SHARP_PIXELS = 3.5; // lower is sharper
 
 vec4 sharpSample(sampler2D tex, vec2 uv) {
     vec2 texSize = vec2(textureSize(tex, 0));

--- a/pc/shaders/default.frag
+++ b/pc/shaders/default.frag
@@ -263,6 +263,24 @@ vec2 applyIndirect(ivec4 ind_cfg, ivec3 ind_wrap, vec2 coord,
     return wrappedCoord + offset;
 }
 
+// A nice trick to make large pixels on screen more pleasing to look at
+// Rather than interpolating over the entire pixel when drawing something linearly, only interpolate on the edges
+// this looks look a lot better when using the original GameCube graphics
+// TEX_SHARPNESS is like blending between LINEAR and NEAREST. (0.0 = completely LINEAR, 1.0 = completely NEAREST)
+
+const float TEX_SHARPNESS = 0.25;
+
+vec4 sharpSample(sampler2D tex, vec2 uv) {
+    vec2 texSize = vec2(textureSize(tex, 0));
+    vec2 t = uv * texSize - 0.5;
+    vec2 i = floor(t);
+    vec2 halfWidth = vec2(max(0.5 * (1.0 - TEX_SHARPNESS), 1e-4));
+    vec2 sharpFrac = clamp(((t-i) - (0.5 - halfWidth)) / (2.0 * halfWidth), 0.0, 1.0);
+
+    vec2 sharpUV = (i + sharpFrac + 0.5) / texSize;
+    return texture(tex, sharpUV);
+}
+
 /* EQUAL/NEQUAL use epsilon for float precision after interpolation */
 bool alphaTest(int comp, float val, float ref) {
     const float EPS = 0.5 / 255.0;
@@ -303,9 +321,9 @@ void main() {
     /* Texture samples. Kept as an explicit 3-way dispatch rather than a
        sampler array so the C side doesn't need to change. */
     vec4 texColor[3];
-    texColor[0] = (u_use_texture[0] != 0) ? texture(u_texture0, stc[0]) : vec4(1.0);
-    texColor[1] = (u_use_texture[1] != 0) ? texture(u_texture1, stc[1]) : vec4(1.0);
-    texColor[2] = (u_use_texture[2] != 0) ? texture(u_texture2, stc[2]) : vec4(1.0);
+    texColor[0] = (u_use_texture[0] != 0) ? sharpSample(u_texture0, stc[0]) : vec4(1.0);
+    texColor[1] = (u_use_texture[1] != 0) ? sharpSample(u_texture1, stc[1]) : vec4(1.0);
+    texColor[2] = (u_use_texture[2] != 0) ? sharpSample(u_texture2, stc[2]) : vec4(1.0);
 
     /* Rasterized color: GX lighting model */
     vec4 rasColor;

--- a/pc/shaders/default.frag
+++ b/pc/shaders/default.frag
@@ -266,15 +266,16 @@ vec2 applyIndirect(ivec4 ind_cfg, ivec3 ind_wrap, vec2 coord,
 // A nice trick to make large pixels on screen more pleasing to look at
 // Rather than interpolating over the entire pixel when drawing something linearly, only interpolate on the edges
 // this looks look a lot better when using the original GameCube graphics
-// TEX_SHARPNESS is like blending between LINEAR and NEAREST. (0.0 = completely LINEAR, 1.0 = completely NEAREST)
 
-const float TEX_SHARPNESS = 0.25;
+const float TEX_SHARP_PIXELS = 5.0;
 
 vec4 sharpSample(sampler2D tex, vec2 uv) {
     vec2 texSize = vec2(textureSize(tex, 0));
     vec2 t = uv * texSize - 0.5;
     vec2 i = floor(t);
-    vec2 halfWidth = vec2(max(0.5 * (1.0 - TEX_SHARPNESS), 1e-4));
+
+    vec2 halfWidth = clamp(0.5 * TEX_SHARP_PIXELS * fwidth(t), .00001, 0.5);
+
     vec2 sharpFrac = clamp(((t-i) - (0.5 - halfWidth)) / (2.0 * halfWidth), 0.0, 1.0);
 
     vec2 sharpUV = (i + sharpFrac + 0.5) / texSize;

--- a/src/game/m_camera2.c
+++ b/src/game/m_camera2.c
@@ -59,7 +59,7 @@ static void Camera2_DirectionCalc(GAME_PLAY* play) {
     camera->direction_velocity.z = camera->direction.z - dir.z;
 }
 
-static int Camera2_InDoorCheck() {
+int Camera2_InDoorCheck() {
     mActor_name_t field_id = mFI_GetFieldId();
     int res = FALSE;
 
@@ -498,12 +498,12 @@ static void Camera2_Get_GoalDistanceAndDirection(GAME_PLAY* play, f32* dist, s_x
     *dist = distance_array[main_index];
     *dir = direction_array[main_index];
 
-// #ifdef PC_ENHANCEMENTS
-//     /* C-stick camera now works in every scene */
-//     if (main_index == CAMERA2_PROCESS_NORMAL) {
-// #else
+#ifdef PC_ENHANCEMENTS
+    /* C-stick camera now works in every scene */
+    if (main_index == CAMERA2_PROCESS_NORMAL) {
+#else
     if (main_index == CAMERA2_PROCESS_NORMAL && Camera2_InDoorCheck()) {
-// #endif
+#endif
         if (add_dist_idx < 0 || add_dist_idx >= 3) {
             add_dist_idx = 1;
         }
@@ -992,6 +992,12 @@ static void Camera2_setup_main_Wade(GAME_PLAY* play) {
 
     Camera2_setup_main_Base(play);
     play->camera.requested_main_index_priority = 9;
+
+#ifdef PC_ENHANCEMENTS
+    /* Reset any outdoor C-stick camera changes instead of a weird double transition */
+    play->camera.indoor_distance_addition_idx = 1;
+    play->camera.indoor_direction_addition_idx = 1;
+#endif
 }
 
 static void Camera2_SetPos_Wade(GAME_PLAY* play) {

--- a/src/game/m_camera2.c
+++ b/src/game/m_camera2.c
@@ -72,7 +72,7 @@ int Camera2_InDoorCheck() {
 }
 
 static int Camera2_CheckInDoorNearFar(GAME_PLAY* play) {
-    if (play->camera.indoor_distance_addition_idx == 0 ||
+    if ((play->camera.indoor_distance_addition_idx == 0 && Camera2_InDoorCheck()) ||
         (Save_Get(scene_no) == SCENE_BROKER_SHOP && play->camera.now_main_index == CAMERA2_PROCESS_TALK)) {
         return TRUE;
     }
@@ -995,8 +995,11 @@ static void Camera2_setup_main_Wade(GAME_PLAY* play) {
 
 #ifdef PC_ENHANCEMENTS
     /* Reset any outdoor C-stick camera changes instead of a weird double transition */
-    play->camera.indoor_distance_addition_idx = 1;
-    play->camera.indoor_direction_addition_idx = 1;
+    if (!mPlib_IsWadeDisabled()){
+        play->camera.indoor_distance_addition_idx = 1;
+        play->camera.indoor_direction_addition_idx = 1;
+    }
+  
 #endif
 }
 

--- a/src/game/m_camera2.c
+++ b/src/game/m_camera2.c
@@ -498,7 +498,12 @@ static void Camera2_Get_GoalDistanceAndDirection(GAME_PLAY* play, f32* dist, s_x
     *dist = distance_array[main_index];
     *dir = direction_array[main_index];
 
+// #ifdef PC_ENHANCEMENTS
+//     /* C-stick camera now works in every scene */
+//     if (main_index == CAMERA2_PROCESS_NORMAL) {
+// #else
     if (main_index == CAMERA2_PROCESS_NORMAL && Camera2_InDoorCheck()) {
+// #endif
         if (add_dist_idx < 0 || add_dist_idx >= 3) {
             add_dist_idx = 1;
         }

--- a/src/game/m_choice_main_normal.c_inc
+++ b/src/game/m_choice_main_normal.c_inc
@@ -26,7 +26,7 @@ static int mChoice_Main_Normal_SetChoice(mChoice_c* choice, GAME* game) {
 
         switch (*choice_automove_p) {
             case mChoice_AUTOMOVE_INCREMENT_WAIT: {
-                if (percent < 0.0f || chkButton(BUTTON_CDOWN)) {
+                if (percent < 0.0f || chkButton(BUTTON_CDOWN) || chkButton(BUTTON_DDOWN)) {
                     (*choice_automove_timer_p) += (f32)gamePT->graph->dt_num_60fps_frames;
 
                     if (*choice_automove_timer_p >= 18.0f) {
@@ -44,7 +44,7 @@ static int mChoice_Main_Normal_SetChoice(mChoice_c* choice, GAME* game) {
             }
 
             case mChoice_AUTOMOVE_INCREMENT: {
-                if (percent < 0.0f || chkButton(BUTTON_CDOWN)) {
+                if (percent < 0.0f || chkButton(BUTTON_CDOWN) || chkButton(BUTTON_DDOWN)) {
                     (*choice_automove_timer_p) += (f32)gamePT->graph->dt_num_60fps_frames;
 
                     if (*choice_automove_timer_p >= 9.0f) {
@@ -61,7 +61,7 @@ static int mChoice_Main_Normal_SetChoice(mChoice_c* choice, GAME* game) {
             }
 
             case mChoice_AUTOMOVE_DECREMENT_WAIT: {
-                if (percent > 0.0f || chkButton(BUTTON_CUP)) {
+                if (percent > 0.0f || chkButton(BUTTON_CUP) || chkButton(BUTTON_DUP)) {
                     (*choice_automove_timer_p) += (f32)gamePT->graph->dt_num_60fps_frames;
 
                     if (*choice_automove_timer_p >= 18.0f) {
@@ -79,7 +79,7 @@ static int mChoice_Main_Normal_SetChoice(mChoice_c* choice, GAME* game) {
             }
 
             case mChoice_AUTOMOVE_DECREMENT: {
-                if (percent > 0.0f || chkButton(BUTTON_CUP)) {
+                if (percent > 0.0f || chkButton(BUTTON_CUP) || chkButton(BUTTON_DUP)) {
                     (*choice_automove_timer_p) += (f32)gamePT->graph->dt_num_60fps_frames;
 
                     if (*choice_automove_timer_p >= 9.0f) {
@@ -96,12 +96,12 @@ static int mChoice_Main_Normal_SetChoice(mChoice_c* choice, GAME* game) {
             }
 
             default: {
-                if (percent > 0.0f || chkTrigger(BUTTON_CUP)) {
+                if (percent > 0.0f || chkTrigger(BUTTON_CUP) || chkTrigger(BUTTON_DUP)) {
                     *choice_automove_p = mChoice_AUTOMOVE_DECREMENT_WAIT;
                     *choice_automove_timer_p = 0.0f;
                     (*selected_idx_p)--;
                     cursor_sfx = TRUE;
-                } else if (percent < 0.0f || chkTrigger(BUTTON_CDOWN)) {
+                } else if (percent < 0.0f || chkTrigger(BUTTON_CDOWN) || chkTrigger(BUTTON_DDOWN)) {
                     *choice_automove_p = mChoice_AUTOMOVE_INCREMENT_WAIT;
                     *choice_automove_timer_p = 0.0f;
                     (*selected_idx_p)++;

--- a/src/game/m_kankyo.c
+++ b/src/game/m_kankyo.c
@@ -1882,9 +1882,7 @@ static void mEnv_SetFog(GAME_PLAY* play, Kankyo* kankyo, Global_light* global_li
 #ifdef PC_ENHANCEMENTS
     /* reset fog if rotated camera with C-stick outside*/
     else if  (play->camera.focus_distance != 620.0){
-        if  (play->camera.now_main_index == CAMERA2_PROCESS_NORMAL
-        ||  (play->camera.last_main_index == CAMERA2_PROCESS_NORMAL && play->camera.now_main_index == CAMERA2_PROCESS_WADE)
-        ){
+        if  (play->camera.now_main_index == CAMERA2_PROCESS_NORMAL || play->camera.now_main_index == CAMERA2_PROCESS_WADE){
             global_light->fogFar = 1000;
             global_light->fogNear = 1000;
         } 

--- a/src/game/m_kankyo.c
+++ b/src/game/m_kankyo.c
@@ -1,5 +1,6 @@
 #include "m_kankyo.h"
 
+#include "m_camera2.h"
 #include "m_room_type.h"
 #include "m_scene_table.h"
 #include "m_common_data.h"
@@ -1853,7 +1854,7 @@ static void mEnv_SetDiffuseLight(Kankyo* kankyo) {
     kankyo->moon_light.lights.diffuse.z = kankyo->base_light.moon_dir[2];
 }
 
-static void mEnv_SetFog(Kankyo* kankyo, Global_light* global_light) {
+static void mEnv_SetFog(GAME_PLAY* play, Kankyo* kankyo, Global_light* global_light) {
     int field_id = mFI_GetFieldId();
     int fog_near;
     int fog_far;
@@ -1878,6 +1879,17 @@ static void mEnv_SetFog(Kankyo* kankyo, Global_light* global_light) {
         global_light->fogFar = 1000;
         global_light->fogNear = 1000;
     }
+#ifdef PC_ENHANCEMENTS
+    /* reset fog if rotated camera with C-stick outside*/
+    else if  (play->camera.focus_distance != 620.0){
+        if  (play->camera.now_main_index == CAMERA2_PROCESS_NORMAL
+        ||  (play->camera.last_main_index == CAMERA2_PROCESS_NORMAL && play->camera.now_main_index == CAMERA2_PROCESS_WADE)
+        ){
+            global_light->fogFar = 1000;
+            global_light->fogNear = 1000;
+        } 
+    }  
+#endif
 }
 
 static void mEnv_PermitCheckDiffuseLight(Kankyo* kankyo) {
@@ -2184,7 +2196,7 @@ extern void Global_kankyo_set(GAME_PLAY* play, Kankyo* kankyo, Global_light* glo
     mEnv_AddAndSetRGBColor(global_light->ambientColor, kankyo->base_light.ambient_color,
                            kankyo->add_light_info.ambient_color);
     mEnv_SetDiffuseLight(kankyo);
-    mEnv_SetFog(kankyo, global_light);
+    mEnv_SetFog(play, kankyo, global_light);
     mEnv_PermitCheckDiffuseLight(kankyo);
     mEnv_TaimatuPointLightWaveMoveProc(play);
     mEnv_CheckNpcLight_ToSwitchON(play);

--- a/src/game/m_msg_cursol.c_inc
+++ b/src/game/m_msg_cursol.c_inc
@@ -1106,9 +1106,9 @@ static int mMsg_Main_Cursol_ControlCursol(mMsg_Window_c* msg_p) {
   int processed = FALSE;
 
 #ifdef PC_ENHANCEMENTS
-  /* B latches fast text for the rest of the message; L/R also speed it up */
+  /* B latches fast text for the rest of the message; L/R or DPAD also speed it up */
   if ((msg_p->status_flags & mMsg_STATUS_FLAG_CURSOL_JUST) == 0 &&
-      (chkTrigger(BUTTON_B) || chkButton(BUTTON_L) || chkButton(BUTTON_R))) {
+      (chkTrigger(BUTTON_B) || chkButton(BUTTON_L) || chkButton(BUTTON_R) || chkButton(BUTTON_DDOWN) || chkButton(BUTTON_DUP) || chkButton(BUTTON_DLEFT) || chkButton(BUTTON_DRIGHT))) {
     msg_p->status_flags |= mMsg_STATUS_FLAG_FAST_TEXT;
   }
 #else

--- a/src/game/m_msg_cursol.c_inc
+++ b/src/game/m_msg_cursol.c_inc
@@ -1119,6 +1119,7 @@ static int mMsg_Main_Cursol_ControlCursol(mMsg_Window_c* msg_p) {
     else {
       msg_p->status_flags &= ~mMsg_STATUS_FLAG_FAST_TEXT;
     }
+  }
 #endif
 
   if (mMsg_Check_CancelOrder(msg_p)) {

--- a/src/game/m_msg_cursol.c_inc
+++ b/src/game/m_msg_cursol.c_inc
@@ -1105,6 +1105,13 @@ static int mMsg_Main_Cursol_ControlCursol(mMsg_Window_c* msg_p) {
   int utter = FALSE;
   int processed = FALSE;
 
+#ifdef PC_ENHANCEMENTS
+  /* B latches fast text for the rest of the message; L/R also speed it up */
+  if ((msg_p->status_flags & mMsg_STATUS_FLAG_CURSOL_JUST) == 0 &&
+      (chkTrigger(BUTTON_B) || chkButton(BUTTON_L) || chkButton(BUTTON_R))) {
+    msg_p->status_flags |= mMsg_STATUS_FLAG_FAST_TEXT;
+  }
+#else
   if ((msg_p->status_flags & mMsg_STATUS_FLAG_CURSOL_JUST) == 0) {
     if (chkButton(BUTTON_B)) {
       msg_p->status_flags |= mMsg_STATUS_FLAG_FAST_TEXT;
@@ -1112,7 +1119,7 @@ static int mMsg_Main_Cursol_ControlCursol(mMsg_Window_c* msg_p) {
     else {
       msg_p->status_flags &= ~mMsg_STATUS_FLAG_FAST_TEXT;
     }
-  }
+#endif
 
   if (mMsg_Check_CancelOrder(msg_p)) {
     msg_p->cancel_flag = TRUE;

--- a/src/game/m_msg_normal.c_inc
+++ b/src/game/m_msg_normal.c_inc
@@ -1,5 +1,9 @@
 static int mMsg_Check_ScrollOrder(mMsg_Window_c* msg_p) {
+#ifdef PC_ENHANCEMENTS
+  return (chkTrigger(BUTTON_A) || chkTrigger(BUTTON_B) || chkTrigger(BUTTON_DDOWN) || chkTrigger(BUTTON_DUP) || chkTrigger(BUTTON_DLEFT) || chkTrigger(BUTTON_DRIGHT));
+#else
   return (chkTrigger(BUTTON_A) || chkTrigger(BUTTON_B));
+#endif
 }
 
 static int mMsg_MsgTimeEnd_dec(mMsg_Window_c* msg_p) {

--- a/src/game/m_player.c
+++ b/src/game/m_player.c
@@ -1464,8 +1464,9 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
 
     #define IS_CUSTOM_UMBRELLA(item) ((item) >= ITM_MY_ORG_UMBRELLA0 && (item) <= ITM_MY_ORG_UMBRELLA7)
 
+    static int last_tool_slot = 0;
+
     static void TrySwitchToolSlot(GAME* game, int direction) {
-        static int last_tool_slot = 0;
         static int last_direction = 0;
         Private_c* priv;
         mActor_name_t held_item;
@@ -1538,6 +1539,7 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
                 return;
             }
             mPr_SetPossessionItem(priv, slot, held_item, 0);
+            last_tool_slot = slot;
         }
 
         priv->equipment = EMPTY_NO;
@@ -1551,7 +1553,7 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
         player = GET_PLAYER_ACTOR_GAME(game);
 
         /* only during free movement (walk/run/stand/dash), not mid-demo */
-        main_index = player->prev_main_index;
+        main_index = player->now_main_index;
         if (main_index < mPlayer_INDEX_WAIT || main_index > mPlayer_INDEX_DASH) {
             return;
         }

--- a/src/game/m_player.c
+++ b/src/game/m_player.c
@@ -1464,10 +1464,11 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
 
     #define IS_CUSTOM_UMBRELLA(item) ((item) >= ITM_MY_ORG_UMBRELLA0 && (item) <= ITM_MY_ORG_UMBRELLA7)
 
+    /* next slot the cycle search starts from; after a putaway, the slot holding the put-away tool */
     static int last_tool_slot = 0;
+    static int last_direction = 0;
 
     static void TrySwitchToolSlot(GAME* game, int direction) {
-        static int last_direction = 0;
         Private_c* priv;
         mActor_name_t held_item;
         mActor_name_t slot_item;
@@ -1494,12 +1495,12 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
             }
         }
 
-        /* direction changed, undo previous step */
+        /* direction changed, undo previous step so the search lands on the tool just swapped out */
         if (last_direction != 0 && direction != last_direction) {
             last_tool_slot = WrapToolSlot(last_tool_slot - last_direction);
         }
 
-        search_slot = WrapToolSlot(last_tool_slot + direction);
+        search_slot = last_tool_slot;
 
         for (i = 0; i < mPr_POCKETS_SLOT_COUNT; i++) {
             slot_item = priv->inventory.pockets[search_slot];
@@ -1513,7 +1514,7 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
                 }
 
                 priv->equipment = slot_item;
-                last_tool_slot = search_slot;
+                last_tool_slot = WrapToolSlot(search_slot + direction);
                 last_direction = direction;
                 Player_actor_request_main_takeout_item(game, mPlayer_REQUEST_PRIORITY_37);
                 return;
@@ -1543,6 +1544,7 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
         }
 
         priv->equipment = EMPTY_NO;
+        last_direction = 0;
         Player_actor_request_main_putin_item(game, 0x25);
     }
 

--- a/src/game/m_player.c
+++ b/src/game/m_player.c
@@ -1563,7 +1563,7 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
         if (Player_actor_Check_is_demo_mode(main_index) != 0) {
             return;
         }
-        if (Player_actor_Check_is_demo_mode(player->requested_main_index_priority) != 0) {
+        if (Player_actor_Check_is_demo_mode(player->requested_main_index) != 0) {
             return;
         }
 

--- a/src/game/m_player.c
+++ b/src/game/m_player.c
@@ -1450,6 +1450,133 @@ static void Player_actor_main_Demo_get_golden_item(ACTOR*, GAME*);
 static void Player_actor_main_Demo_get_golden_item2(ACTOR*, GAME*);
 static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
 
+#ifdef PC_ENHANCEMENTS
+
+    static int WrapToolSlot(int slot) {
+        if (slot < 0) {
+            return mPr_POCKETS_SLOT_COUNT - 1;
+        }
+        if (slot >= mPr_POCKETS_SLOT_COUNT) {
+            return 0;
+        }
+        return slot;
+    }
+
+    #define IS_CUSTOM_UMBRELLA(item) ((item) >= ITM_MY_ORG_UMBRELLA0 && (item) <= ITM_MY_ORG_UMBRELLA7)
+
+    static void TrySwitchToolSlot(GAME* game, int direction) {
+        static int last_tool_slot = 0;
+        static int last_direction = 0;
+        Private_c* priv;
+        mActor_name_t held_item;
+        mActor_name_t slot_item;
+        int search_slot;
+        int i;
+
+        priv = Common_Get(now_private);
+        held_item = priv->equipment;
+
+        if (last_tool_slot < 0 || last_tool_slot >= mPr_POCKETS_SLOT_COUNT) {
+            last_tool_slot = 0;
+        }
+
+        /* try last used slot first */
+        if (held_item == EMPTY_NO) {
+            slot_item = priv->inventory.pockets[last_tool_slot];
+
+            if (mPr_GET_ITEM_COND(priv->inventory.item_conditions, last_tool_slot) == mPr_ITEM_COND_NORMAL &&
+                ITEM_IS_TOOL(slot_item)) {
+                priv->equipment = slot_item;
+                mPr_SetPossessionItem(priv, last_tool_slot, EMPTY_NO, 0);
+                Player_actor_request_main_takeout_item(game, mPlayer_REQUEST_PRIORITY_37);
+                return;
+            }
+        }
+
+        /* direction changed, undo previous step */
+        if (last_direction != 0 && direction != last_direction) {
+            last_tool_slot = WrapToolSlot(last_tool_slot - last_direction);
+        }
+
+        search_slot = WrapToolSlot(last_tool_slot + direction);
+
+        for (i = 0; i < mPr_POCKETS_SLOT_COUNT; i++) {
+            slot_item = priv->inventory.pockets[search_slot];
+
+            if (mPr_GET_ITEM_COND(priv->inventory.item_conditions, search_slot) == mPr_ITEM_COND_NORMAL &&
+                ITEM_IS_TOOL(slot_item)) {
+                if (held_item != EMPTY_NO && !IS_CUSTOM_UMBRELLA(held_item)) {
+                    mPr_SetPossessionItem(priv, search_slot, held_item, 0);
+                } else {
+                    mPr_SetPossessionItem(priv, search_slot, EMPTY_NO, 0);
+                }
+
+                priv->equipment = slot_item;
+                last_tool_slot = search_slot;
+                last_direction = direction;
+                Player_actor_request_main_takeout_item(game, mPlayer_REQUEST_PRIORITY_37);
+                return;
+            }
+
+            search_slot = WrapToolSlot(search_slot + direction);
+        }
+    }
+
+    static void TryPutawayTool(GAME* game) {
+        Private_c* priv = Common_Get(now_private);
+        mActor_name_t held_item = priv->equipment;
+        int slot;
+
+        if (held_item == EMPTY_NO) {
+            return;
+        }
+
+        if (!IS_CUSTOM_UMBRELLA(held_item)) {
+            slot = mPr_GetPossessionItemIdx(priv, EMPTY_NO);
+            if (slot == -1) {
+                sAdo_SysTrgStart(0x100A);
+                return;
+            }
+            mPr_SetPossessionItem(priv, slot, held_item, 0);
+        }
+
+        priv->equipment = EMPTY_NO;
+        Player_actor_request_main_putin_item(game, 0x25);
+    }
+
+    static void Player_actor_check_and_switch_tool(GAME* game) {
+        PLAYER_ACTOR* player;
+        int main_index;
+
+        player = GET_PLAYER_ACTOR_GAME(game);
+
+        /* only during free movement (walk/run/stand/dash), not mid-demo */
+        main_index = player->prev_main_index;
+        if (main_index < mPlayer_INDEX_WAIT || main_index > mPlayer_INDEX_DASH) {
+            return;
+        }
+
+        if (Player_actor_Check_is_demo_mode(main_index) != 0) {
+            return;
+        }
+        if (Player_actor_Check_is_demo_mode(player->requested_main_index_priority) != 0) {
+            return;
+        }
+
+        if (chkTrigger(BUTTON_DLEFT)) {
+            TrySwitchToolSlot(game, -1);
+            return;
+        }
+        if (chkTrigger(BUTTON_DRIGHT)) {
+            TrySwitchToolSlot(game, 1);
+            return;
+        }
+        if (chkTrigger(BUTTON_DDOWN)) {
+            TryPutawayTool(game);
+        }
+    }
+#endif
+
 extern void Player_actor_move(ACTOR* actorx, GAME* game) {
     static const mPlayer_MAIN_PROC proc[] = {
         &Player_actor_main_Dma,
@@ -1585,6 +1712,10 @@ extern void Player_actor_move(ACTOR* actorx, GAME* game) {
 
     (*proc[idx])(actorx, game);
     Player_actor_move_other_func2(actorx, game); //
+
+#ifdef PC_ENHANCEMENTS
+    Player_actor_check_and_switch_tool(game);
+#endif
 }
 
 typedef void (*mPlayer_DRAW_PROC)(ACTOR*, GAME*);

--- a/src/game/m_player.c
+++ b/src/game/m_player.c
@@ -1549,8 +1549,17 @@ static void Player_actor_main_Demo_get_golden_axe_wait(ACTOR*, GAME*);
     }
 
     static void Player_actor_check_and_switch_tool(GAME* game) {
+        GAME_PLAY* play = (GAME_PLAY*)game;
         PLAYER_ACTOR* player;
         int main_index;
+
+        /* outdoors only, and not while a submenu is open or opening */
+        if (mFI_GET_TYPE(mFI_GetFieldId()) != mFI_FIELDTYPE2_FG ||
+            play->submenu.start_refuse ||
+            play->submenu.current_menu_type != mSM_OVL_NONE ||
+            play->submenu.menu_type != mSM_OVL_NONE) {
+            return;
+        }
 
         player = GET_PLAYER_ACTOR_GAME(game);
 

--- a/src/game/m_player_controller.c_inc
+++ b/src/game/m_player_controller.c_inc
@@ -116,7 +116,14 @@ static int Player_actor_CheckController_forShake_tree(GAME* game) {
     PLAYER_ACTOR* player = (PLAYER_ACTOR*)actorx;
     s8 kind = Player_actor_Get_ItemKind(actorx, player->now_main_index);
 
+#ifdef PC_ENHANCEMENTS
+    /* net/rod no longer block tree shaking */
+    if (!mPlayer_ITEM_KIND_CHECK(kind, 0, mPlayer_ITEM_KIND_NUM) ||
+        mPlayer_ITEM_IS_NOT_TOOL(kind) != FALSE ||
+        mPlayer_ITEM_IS_NET(kind) || mPlayer_ITEM_IS_ROD(kind)) {
+#else
     if (!mPlayer_ITEM_KIND_CHECK(kind, 0, mPlayer_ITEM_KIND_NUM) || mPlayer_ITEM_IS_NOT_TOOL(kind) != FALSE) {
+#endif
         if (mEv_IsTitleDemo()) {
             mPlayer_Controller_Data_c* data = mPlib_Get_controller_data_for_title_demo_p();
             return (data->trigger_btn_a != 0) && (data->btn_b == 0);

--- a/src/game/m_player_lib.c
+++ b/src/game/m_player_lib.c
@@ -3331,16 +3331,16 @@ extern int mPlib_Check_scoop_after(GAME* game, xyz_t* pos_p, mActor_name_t* item
 
 extern int mPlib_Check_scene_able_change_camera_pos(void) {
     if (mFI_CheckFieldData()) {
-// #if PC_ENHANCEMENTS
-//         /* C-stick camera now works in every scene */
-//         return TRUE;
-// #else
+#if PC_ENHANCEMENTS
+        /* C-stick camera now works in every scene */
+        return TRUE;
+#else
         int field_type = mFI_GET_TYPE(mFI_GetFieldId());
 
         return (field_type == mFI_FIELD_NPCROOM0 || field_type == mFI_FIELD_PLAYER0_ROOM ||
                 Save_Get(scene_no) == SCENE_MUSEUM_ROOM_FOSSIL || Save_Get(scene_no) == SCENE_MUSEUM_ROOM_PAINTING ||
                 Save_Get(scene_no) == SCENE_MUSEUM_ROOM_INSECT || Save_Get(scene_no) == SCENE_MUSEUM_ROOM_FISH);
-// #endif
+#endif
     }
 
     return FALSE;

--- a/src/game/m_player_lib.c
+++ b/src/game/m_player_lib.c
@@ -3331,11 +3331,16 @@ extern int mPlib_Check_scoop_after(GAME* game, xyz_t* pos_p, mActor_name_t* item
 
 extern int mPlib_Check_scene_able_change_camera_pos(void) {
     if (mFI_CheckFieldData()) {
+// #if PC_ENHANCEMENTS
+//         /* C-stick camera now works in every scene */
+//         return TRUE;
+// #else
         int field_type = mFI_GET_TYPE(mFI_GetFieldId());
 
         return (field_type == mFI_FIELD_NPCROOM0 || field_type == mFI_FIELD_PLAYER0_ROOM ||
                 Save_Get(scene_no) == SCENE_MUSEUM_ROOM_FOSSIL || Save_Get(scene_no) == SCENE_MUSEUM_ROOM_PAINTING ||
                 Save_Get(scene_no) == SCENE_MUSEUM_ROOM_INSECT || Save_Get(scene_no) == SCENE_MUSEUM_ROOM_FISH);
+// #endif
     }
 
     return FALSE;

--- a/src/game/m_player_main_pickup.c_inc
+++ b/src/game/m_player_main_pickup.c_inc
@@ -29,6 +29,9 @@ static void Player_actor_setup_main_Pickup(ACTOR* actorx, GAME* game) {
     int signboard_flag;
     int anim1_idx;
     int part_table_idx;
+#ifdef PC_ENHANCEMENTS
+    int putaway_money = FALSE;
+#endif
 
     slot_idx = req_pickup_p->inv_slot;
     item = req_pickup_p->item;
@@ -50,14 +53,15 @@ static void Player_actor_setup_main_Pickup(ACTOR* actorx, GAME* game) {
     }
 
 #ifdef PC_ENHANCEMENTS
-    /* bells go straight to wallet, not a pocket slot */
+    /* bells go straight to wallet when the whole amount fits; otherwise the bag is picked up normally */
     {
         u32 bell_amount = mPr_GetAmountForMoneyItem(item);
-        if (bell_amount > 0) {
-            mPr_GivePossessionBells(bell_amount);
+        if (bell_amount > 0 && mPr_GivePossessionBells(bell_amount)) {
+            sAdo_SysTrgStart(SE_REGISTER);
             if (target_pos_p != NULL) {
                 mFI_SetFG_common(EMPTY_NO, *target_pos_p, TRUE);
             }
+            putaway_money = TRUE;
         } else {
             Player_actor_putin_item(slot_idx, item, target_pos_p);
         }
@@ -66,6 +70,12 @@ static void Player_actor_setup_main_Pickup(ACTOR* actorx, GAME* game) {
     Player_actor_putin_item(slot_idx, item, target_pos_p);
 #endif
 
+#ifdef PC_ENHANCEMENTS
+    /* the bells never entered a pocket, so the pockets-full exchange must not offer them again. money duplication otherwise. */
+    if (putaway_money) {
+        main_pickup_p->exchange_flag = FALSE;
+    } else
+#endif
     if (slot_idx >= 0) {
         main_pickup_p->exchange_flag = FALSE;
     } else if (mEv_IsTitleDemo()) {

--- a/src/game/m_player_main_pickup.c_inc
+++ b/src/game/m_player_main_pickup.c_inc
@@ -49,7 +49,22 @@ static void Player_actor_setup_main_Pickup(ACTOR* actorx, GAME* game) {
         aSIGN_erase_white_sign(game, target_pos_p);
     }
 
+#ifdef PC_ENHANCEMENTS
+    /* bells go straight to wallet, not a pocket slot */
+    {
+        u32 bell_amount = mPr_GetAmountForMoneyItem(item);
+        if (bell_amount > 0) {
+            mPr_GivePossessionBells(bell_amount);
+            if (target_pos_p != NULL) {
+                mFI_SetFG_common(EMPTY_NO, *target_pos_p, TRUE);
+            }
+        } else {
+            Player_actor_putin_item(slot_idx, item, target_pos_p);
+        }
+    }
+#else
     Player_actor_putin_item(slot_idx, item, target_pos_p);
+#endif
 
     if (slot_idx >= 0) {
         main_pickup_p->exchange_flag = FALSE;

--- a/src/game/m_private.c
+++ b/src/game/m_private.c
@@ -1510,30 +1510,14 @@ extern u32 mPr_GetAmountForMoneyItem(mActor_name_t item) {
     return 0;
 }
 
-/* deposit bells to wallet, overflow into bank */
+/* deposit bells to wallet; fails without change unless the whole amount fits */
 extern int mPr_GivePossessionBells(u32 amount) {
-    u32 wallet_space;
-    u32 bank_space;
-    u32 to_wallet;
-    u32 to_bank;
-
-    wallet_space = mPr_WALLET_MAX - Now_Private->inventory.wallet;
-    if (amount <= wallet_space) {
-        Now_Private->inventory.wallet += amount;
-        return TRUE;
+    if (amount > mPr_WALLET_MAX - Now_Private->inventory.wallet) {
+        return FALSE;
     }
 
-    Now_Private->inventory.wallet = mPr_WALLET_MAX;
-    amount -= wallet_space;
-
-    bank_space = mPr_DEPOSIT_MAX - Now_Private->bank_account;
-    if (amount <= bank_space) {
-        Now_Private->bank_account += amount;
-        return TRUE;
-    }
-
-    Now_Private->bank_account = mPr_DEPOSIT_MAX;
-    return FALSE;
+    Now_Private->inventory.wallet += amount;
+    return TRUE;
 }
 
 #endif

--- a/src/game/m_private.c
+++ b/src/game/m_private.c
@@ -1485,3 +1485,55 @@ extern void mPr_PrintMapInfo_debug(gfxprint_t* gfxprint) {
         }
     }
 }
+
+#ifdef PC_ENHANCEMENTS
+/* bell amount for a money-bag item, 0 if not one */
+extern u32 mPr_GetAmountForMoneyItem(mActor_name_t item) {
+    int type = mNT_get_itemTableNo(item);
+    int idx = item & 0xFF;
+
+    if (type != 9) return 0;
+
+    switch (idx) {
+        case 0: return 1000;
+        case 1: return 10000;
+        case 2: return 30000;
+    }
+
+    if (idx >= 3 && idx <= 0x0B) {
+        return (u32)(idx - 2) * 100;
+    }
+    if (idx >= 0x0C && idx <= 0x6E) {
+        return (u32)(idx - 0x0B) * 1000;
+    }
+
+    return 0;
+}
+
+/* deposit bells to wallet, overflow into bank */
+extern int mPr_GivePossessionBells(u32 amount) {
+    u32 wallet_space;
+    u32 bank_space;
+    u32 to_wallet;
+    u32 to_bank;
+
+    wallet_space = mPr_WALLET_MAX - Now_Private->inventory.wallet;
+    if (amount <= wallet_space) {
+        Now_Private->inventory.wallet += amount;
+        return TRUE;
+    }
+
+    Now_Private->inventory.wallet = mPr_WALLET_MAX;
+    amount -= wallet_space;
+
+    bank_space = mPr_DEPOSIT_MAX - Now_Private->bank_account;
+    if (amount <= bank_space) {
+        Now_Private->bank_account += amount;
+        return TRUE;
+    }
+
+    Now_Private->bank_account = mPr_DEPOSIT_MAX;
+    return FALSE;
+}
+
+#endif

--- a/src/game/m_submenu.c
+++ b/src/game/m_submenu.c
@@ -8,6 +8,10 @@
 #include "m_quest.h"
 #include "libultra/libultra.h"
 
+#ifdef PC_ENHANCEMENTS
+#include "m_museum_display.h"
+#endif
+
 static mSM_dlftbl_c SubmenuArea_dlftbl[mSM_DLF_NUM] = { { NULL, 0, 0, 0, 0, 0, "submenu_ovl" },
                                                         { NULL, 0, 0, 0, 0, 0, "player_actor" } };
 
@@ -572,7 +576,16 @@ static int mSM_check_item_for_curator(int slot_no, int param_2) {
 
     if (item != EMPTY_NO && mPr_GET_ITEM_COND(priv->inventory.item_conditions, slot_no) == mPr_ITEM_COND_NORMAL &&
         item != ITM_KNIFE_AND_FORK && !(item >= ITM_EXCERCISE_CARD00 && item <= ITM_EXCERCISE_CARD12)) {
+#ifdef PC_ENHANCEMENTS
+        /* only show items the curator can accept */
+        if (item == ITM_FOSSIL) {
+            res = TRUE; /* fossils are always selectable */
+        } else if (mMmd_GetDisplayInfo(item) == mMmd_DISPLAY_CAN_DONATE) {
+            res = TRUE;
+        }
+#else
         res = TRUE;
+#endif
     }
 
     return res;

--- a/src/game/m_submenu_ovl.c
+++ b/src/game/m_submenu_ovl.c
@@ -2141,6 +2141,11 @@ static void mSM_make_trigger_data(Submenu* submenu) {
     int trigger = (getButton() & 0xF) | getTrigger();
     mSM_Control_c* control = &submenu->overlay->menu_control;
 
+#ifdef PC_ENHANCEMENTS
+    /* D-Pad bits sit at the same positions as the C-stick bits, shifted left by 8 */
+    trigger |= (getButton() & (BUTTON_DUP | BUTTON_DDOWN | BUTTON_DLEFT | BUTTON_DRIGHT)) >> 8;
+#endif
+
     if (gamePT->mcon.move_pR > 0.5f) {
         u16 angle = gamePT->mcon.move_angle + DEG2SHORT_ANGLE2(45.0f);
 

--- a/src/game/m_submenu_ovl.c
+++ b/src/game/m_submenu_ovl.c
@@ -2144,6 +2144,7 @@ static void mSM_make_trigger_data(Submenu* submenu) {
 #ifdef PC_ENHANCEMENTS
     /* D-Pad bits sit at the same positions as the C-stick bits, shifted left by 8 */
     trigger |= (getButton() & (BUTTON_DUP | BUTTON_DDOWN | BUTTON_DLEFT | BUTTON_DRIGHT)) >> 8;
+    trigger &= ~(BUTTON_DUP | BUTTON_DDOWN | BUTTON_DLEFT | BUTTON_DRIGHT);
 #endif
 
     if (gamePT->mcon.move_pR > 0.5f) {

--- a/src/game/m_tag_ovl.c
+++ b/src/game/m_tag_ovl.c
@@ -4326,7 +4326,11 @@ static int mTG_mark_enable_check(int menu_type, int param, int table, u8 field_t
                             }
                             break;
                         case mTG_TABLE_MAIL:
-                            if (field_type == mFI_FIELDTYPE2_FG) {
+                            /* mail can be deleted indoors too */
+                        #ifndef PC_ENHANCEMENTS
+                            if (field_type == mFI_FIELDTYPE2_FG) 
+                        #endif
+                            {
                                 res = mTG_MARK_TYPE_INV_FG_MAIL;
                             }
                             break;

--- a/src/game/m_watch_my_step.c
+++ b/src/game/m_watch_my_step.c
@@ -19,6 +19,8 @@
 #include "m_scene_table.h"
 #include "m_private.h"
 
+extern int Camera2_InDoorCheck(void);
+
 typedef struct watch_my_step_s {
     f32 pos_x;
     f32 pos_y;
@@ -296,7 +298,8 @@ static void navigate_camera_move(GAME_PLAY* play) {
 
     switch (S_navigate.mode) {
         case 0: {
-            if (mPlib_check_able_change_camera_normal_index() != 0 && play->fb_fade_type == FADE_TYPE_NONE) {
+            // always hide camera controls popup when outdoors or when can't control camera
+            if (mPlib_check_able_change_camera_normal_index() != 0 && play->fb_fade_type == FADE_TYPE_NONE && Camera2_InDoorCheck()) {
                 S_navigate.timer = 150.0f;
                 S_navigate.mode++;
             }


### PR DESCRIPTION
Added the following quality of life changes, most of which can also be found in Animal Crossing Deluxe:
- Quick switch between tools with the D-pad
- Toggle text speed with B or hold to speed up with L/R
- Can shake trees while holding net/fishing rod
- Can only select items that can still be donated in the museum donation menu
- Delete mail indoors (Can easily be removed if you still think this is scary. see: src/game/m_tag_ovl.c)
- Picked up bells go directly to your wallet
- Can use D-Pad in many more menus to make selections
- Camera can also be controlled outdoors (works properly with acreless mode)
- Sharper rendering when using original gamecube graphics